### PR TITLE
Remove unnecessary reference to 'no naked new' in ES.62

### DIFF
--- a/CppCoreGuidelines.md
+++ b/CppCoreGuidelines.md
@@ -7701,7 +7701,7 @@ There can be code in the `...` part that causes the `delete` never to happen.
 		if (0<&a1[5]-&a2[7])	// bad: undefined
 	}
 	
-**Note**: This example also violates the [no naked `new` rule](#Res-new) and has many more problems.
+**Note**: This example has many more problems.
 
 **Enforcement**:
 


### PR DESCRIPTION
This is a minor change to fix an incorrect note in ES.62 (it looks like the not was just copied from above, verbatim). I thought it would be uncontroversial, so I didn't make an issue. Hope that's not a problem.