### PR TITLE
Update CppCoreGuidelines.md

### DIFF
--- a/CppCoreGuidelines.md
+++ b/CppCoreGuidelines.md
@@ -12008,7 +12008,7 @@ Never allow an error to be reported from a destructor, a resource deallocation f
 class nefarious {
 public:
     nefarious()  { /* code that could throw */ }   // ok
-    ~nefarious() { /* code that could throw */ }   // BAD, should be noexcept
+    ~nefarious() { /* code that could throw */ }   // BAD, should not throw
     // ...
 };
 ```


### PR DESCRIPTION
Destructors are always marked as noexcept (unless noexcept(false)) using this word here is ambigious.