### PR TITLE
Suggested example for ES.100 - Don't mix signed and unsigned arithmetic

### DIFF
--- a/CppCoreGuidelines.md
+++ b/CppCoreGuidelines.md
@@ -8394,7 +8394,9 @@ This example has many more problems.
 
 ##### Example
 
-	???
+  unsigned x = 100;
+  unsigned y = 102;  
+  cout << abs(x-y) << '\n'; //wrong result
 
 ##### Note
 

--- a/CppCoreGuidelines.md
+++ b/CppCoreGuidelines.md
@@ -8394,9 +8394,9 @@ This example has many more problems.
 
 ##### Example
 
-  unsigned x = 100;
-  unsigned y = 102;  
-  cout << abs(x-y) << '\n'; //wrong result
+	unsigned x = 100;
+	unsigned y = 102;  
+	cout << abs(x-y) << '\n'; //wrong result
 
 ##### Note
 


### PR DESCRIPTION
In the suggested example, abs requires a signed number but x-y is unsigned.
The execution will not give the expected result, which is 2.