### PR TITLE
Added capture in lambda expression...

### DIFF
--- a/CppCoreGuidelines.md
+++ b/CppCoreGuidelines.md
@@ -9325,7 +9325,7 @@ Let cleanup actions on the unwinding path be handled by [RAII](#Re-raii).
 	void f(int n)
 	{
 		void* p = malloc(1, n);
-		auto _ = finally([] { free(p); });
+		auto _ = finally([p] { free(p); });
 		// ...
 	}
 


### PR DESCRIPTION
In the code snippet that demonstrates how to use the finally method, the capture clause is missing from the lambda expression in order to pass it into the free function...