### PR TITLE
Enforcement rule for I.3: Avoid singletons

### DIFF
--- a/CppCoreGuidelines.md
+++ b/CppCoreGuidelines.md
@@ -1049,6 +1049,7 @@ Very hard in general
 
 * Look for classes with name that includes `singleton`
 * Look for classes for which only a single object is created (by counting objects or by examining constructors)
+* Look for every class T where one of the static data members or static local variables is of type T, T* or T&.
 
 ### <a name="Ri-typed"></a> I.4: Make interfaces precisely and strongly typed
 
@@ -5965,7 +5966,6 @@ Here, we ignore such cases.
   * [R.15: Always overload matched allocation/deallocation pairs](#Rr-pair)
 
 * <a name="Rr-summary-smartptrs"></a> Smart pointer rule summary:
-
   * [R.20: Use `unique_ptr` or `shared_ptr` to represent ownership](#Rr-owner)
   * [R.21: Prefer `unique_ptr` over `shared_ptr` unless you need to share ownership](#Rr-unique)
   * [R.22: Use `make_shared()` to make `shared_ptr`s](#Rr-make_shared)
@@ -6842,7 +6842,7 @@ Arithmetic rules:
 * [ES.101: use unsigned types for bit manipulation](#Res-unsigned)
 * [ES.102: Used signed types for arithmetic](#Res-signed)
 * [ES.103: Don't overflow](#Res-overflow)
-* [ES.104: Don't underflow](#Res-underflow)
+* [ES.104: Don't underflow](#Res-overflow)
 * [ES.105: Don't divide by zero](#Res-zero)
 
 ### <a name="Res-lib"></a> ES.1: Prefer the standard library to other libraries and to "handcrafted code"
@@ -8461,7 +8461,7 @@ Incrementing a value beyond a maximum value can lead to memory corruption and un
 
 ???
 
-### <a name="Res-underflow"></a> ES.104: Don't underflow
+### <a name="Res-overflow"></a> ES.104: Don't underflow
 
 ##### Reason
 
@@ -10590,8 +10590,7 @@ In many cases you can provide a stable interface by not parameterizing a base; s
 ##### Enforcement
 
 * Flag virtual functions that depend on a template argument. ??? False positives
-
-### <a name="Rt-array"></a> T.81: Do not mix hierarchies and arrays
+  ### <a name="Rt-array"></a> T.81: Do not mix hierarchies and arrays
 
 ##### Reason
 
@@ -11103,7 +11102,6 @@ Use a C++ compiler.
 ##### Enforcement
 
 * Flag if using a build mode that compiles code as C.
-
   * The C++ compiler will enforce that the code is valid C++ unless you use C extension options.
 
 ### <a name="Rcpl-interface"></a> CPL.3: If you must use C for interfaces, use C++ in the calling code using such interfaces
@@ -13352,7 +13350,7 @@ Alternatively, we will decide that no change is needed and delete the entry.
   \[Meyers96\]:        S. Meyers. More Effective C++ (Addison-Wesley, 1996).
 * <a name="Meyers97"></a>
   \[Meyers97\]:        S. Meyers. Effective C++ (2ndEdition) (Addison-Wesley, 1997).
-* <a name="Meyers14"></a>
+* <a name="Meyers97"></a>
   \[Meyers14\]:        S. Meyers. Effective Modern C++ (Addison-Wesley, 2014).
 * <a name="Murray93"></a>
   \[Murray93\]:        R. Murray. C++ Strategies and Tactics (Addison-Wesley, 1993).


### PR DESCRIPTION
Look for every class T where one of the static data members or static local variables is of type T, T* or T&.