### PR TITLE
Added an example and a suggestion for an empty virtual destructor to C.121

### DIFF
--- a/CppCoreGuidelines.md
+++ b/CppCoreGuidelines.md
@@ -5109,11 +5109,29 @@ not using this (over)general interface in favor of a particular interface found 
 
 ##### Reason
 
- A class is more stable (less brittle) if it does not contain data. Interfaces should normally be composed entirely of public pure virtual functions.
+ A class is more stable (less brittle) if it does not contain data. Interfaces should normally be composed entirely of public pure virtual functions and an empty virtual destructor.
 
 ##### Example
 
-    ???
+    class shape_interface
+    {
+    public:
+        virtual void draw() = 0;
+        virtual void move() = 0;
+        virtual void erase() = 0;
+        virtual ~shape_interface() {}
+    };
+    
+    class triangle : public shape_interface
+    {
+        //...
+    };
+    
+    void use()
+    {
+        unique_ptr<shape_interface> shape = my_factory.create_triangle();
+        //...
+    }
 
 ##### Enforcement
 


### PR DESCRIPTION
Added an example and a suggestion for an empty virtual destructor to C.121: If a base class is used as an interface, make it a pure abstract class.

This is the classical case where the omission of a virtual destructor in the interface would cause a memory leak.