### PR TITLE
fix to code example for C.61

### DIFF
--- a/CppCoreGuidelines.md
+++ b/CppCoreGuidelines.md
@@ -4403,7 +4403,7 @@ After a copy `x` and `y` can be independent objects (value semantics, the way no
 
     bool operator==(const X& a, const X& b)
     {
-        return sz == a.sz && equal(p, p + sz, a.p, a.p + sz);
+        return a.sz == b.sz && equal(a.p, a.p + a.sz, b.p, b.p + b.sz);
     }
 
     X::X(const X& a)

--- a/CppCoreGuidelines.md
+++ b/CppCoreGuidelines.md
@@ -4434,7 +4434,7 @@ After a copy `x` and `y` can be independent objects (value semantics, the way no
 
     bool operator==(const X2& a, const X2& b)
     {
-        return sz == a.sz && p == a.p;
+        return a.sz == b.sz && a.p == b.p;
     }
 
     X2 x;


### PR DESCRIPTION
Two argument comparison operator in code example for "C.61: A copy operation should copy" has a body of single argument member operator. This fix keeps comparison operator outside class, but corrects its body.