### PR TITLE
F.44: Return a `T&` when "returning no object" isn't an option

### DIFF
--- a/CppCoreGuidelines.md
+++ b/CppCoreGuidelines.md
@@ -2752,7 +2752,20 @@ The language guarantees that a `T&` refers to an object, so that testing for `nu
 
 ##### Example
 
-    ???
+    class car
+    {
+      vector<wheel> w;
+      // ...
+    public:
+      wheel& get_wheel(size_t i) { return w[i]; }
+      // ...
+    };
+    
+    void use()
+    {
+      car c;
+      wheel& w0 = c.get_wheel(0); // w0 has the same lifetime as c
+    }
 
 ##### Enforcement
 


### PR DESCRIPTION
F.44: Return a `T&` when "returning no object" isn't an option.
Example with emphasis on the lifetime of the returned object.