### PR TITLE
Fix possible undefined behavior in the code example in section P.5

### DIFF
--- a/CppCoreGuidelines.md
+++ b/CppCoreGuidelines.md
@@ -554,16 +554,16 @@ Code clarity and performance. You don't need to write error handlers for errors 
 
 ##### Example
 
-    void initializer(Int x)
-    // Int is an alias used for integers
+    void initializer(Uint x)
+    // Uint is an alias used for unsigned integers
     {
-        static_assert(sizeof(Int) >= 4);    // do: compile-time check
+        static_assert(sizeof(Uint) >= 4);       // do: compile-time check
 
-        int bits = 0;         // don't: avoidable code
-        for (Int i = 1; i; i <<= 1)
+        int bits = 0;                           // don't: avoidable code
+        for (Uint i = 1; i; i <<= 1)
             ++bits;
         if (bits < 32)
-            cerr << "Int too small\n";
+            cerr << "Uint too small\n";
 
         // ...
     }


### PR DESCRIPTION
The comment in this example says "Int is an alias used for integers". If `Int` has signed type then shifts will eventually make variable `i` negative and the next shift will invoke undefined behavior (in any version of the standard; shifting 1 into the sign bit was also undefined prior to C++14).
Though this is an anti-example, it is considered bad because it performs some checks at run time (but not because of UB). I propose to make the type unsigned to get rid of undefined behavior.
