### PR TITLE
Empty stubs for Rules T.67 and T.68 added

### DIFF
--- a/CppCoreGuidelines.md
+++ b/CppCoreGuidelines.md
@@ -10893,6 +10893,34 @@ When `concept`s become available such alternatives can be distinguished directly
 
 ???
 
+### <a name="Rt-specialization2"></a> T.67: Use specialization to provide alternative implementations for irregular types
+
+##### Reason
+
+ ???
+
+##### Example
+
+    ???
+
+##### Enforcement
+
+???
+
+### <a name="Rt-cast"></a> T.68: Use `{}` rather than `()` within templates to avoid ambiguities
+
+##### Reason
+
+ ???
+
+##### Example
+
+    ???
+
+##### Enforcement
+
+???
+
 ### <a name="Rt-customization"></a> T.69: Inside a template, don't make an unqualified nonmember function call unless you intend it to be a customization point
 
 ##### Reason

--- a/CppCoreGuidelines.md
+++ b/CppCoreGuidelines.md
@@ -5073,11 +5073,123 @@ Summary of container rules:
 * [C.102: Give a container move operations](#Rcon-move)
 * [C.103: Give a container an initializer list constructor](#Rcon-init)
 * [C.104: Give a container a default constructor that sets it to empty](#Rcon-empty)
-* [C.105: Give a constructor and `Extent` constructor](#Rcon-val)
+* [C.105: Give a constructor and `Extent` constructor](#Rcon-extent)
 * ???
-* [C.109: If a resource handle has pointer semantics, provide `*` and `->`](#rcon-ptr)
+* [C.109: If a resource handle has pointer semantics, provide `*` and `->`](#Rcon-ptr)
 
 **See also**: [Resources](#S-resource)
+
+### <a name="Rcon-stl"></a> C.100: Follow the STL when defining a container
+
+???
+
+##### Reason
+
+ ???
+
+##### Example
+
+    ???
+
+##### Enforcement
+
+???
+
+### <a name="Rcon-val"></a> C.101: Give a container value semantics
+
+???
+
+##### Reason
+
+ ???
+
+##### Example
+
+    ???
+
+##### Enforcement
+
+???
+
+### <a name="Rcon-move"></a> C.102: Give a container move operation
+
+???
+
+##### Reason
+
+ ???
+
+##### Example
+
+    ???
+
+##### Enforcement
+
+???
+
+### <a name="Rcon-init"></a> C.103: Give a container an initializer list constructor
+
+???
+
+##### Reason
+
+ ???
+
+##### Example
+
+    ???
+
+##### Enforcement
+
+???
+
+### <a name="Rcon-empty"></a> C.104: Give a container a default constructor that sets it to empty
+
+???
+
+##### Reason
+
+ ???
+
+##### Example
+
+    ???
+
+##### Enforcement
+
+???
+
+### <a name="Rcon-extent"></a> C.105: Give a constructor and `Extent` constructor
+
+???
+
+##### Reason
+
+ ???
+
+##### Example
+
+    ???
+
+##### Enforcement
+
+???
+
+### <a name="Rcon-ptr"></a> C.109: If a resource handle has pointer semantics, provide `*` and `->`
+
+???
+
+##### Reason
+
+ ???
+
+##### Example
+
+    ???
+
+##### Enforcement
+
+???
 
 ## <a name="SS-lambdas"></a> C.lambdas: Function objects and lambdas
 


### PR DESCRIPTION
Rules T.67 and T.68 are missing, but referenced. Empty stubs added.