### PR TITLE
Fix misplaced end parenthesis in NL.17.Reason

### DIFF
--- a/CppCoreGuidelines.md
+++ b/CppCoreGuidelines.md
@@ -12962,7 +12962,7 @@ Flag departures from the suggested order. There will be a lot of old code that d
 
 ##### Reason
 
-This is the original C and C++ layout. It preserves vertical space well. It distinguishes different language constructs (such as functions and classes well).
+This is the original C and C++ layout. It preserves vertical space well. It distinguishes different language constructs (such as functions and classes) well.
 
 ##### Note
 


### PR DESCRIPTION
The original text has an end parenthesis at the end of a sentence, but it should be at the end of the next-to-last word to make the sentence grammatically correct.