### PR TITLE
Resolve races on shutdown as well as initialization by heap allocating

### DIFF
--- a/CppCoreGuidelines.md
+++ b/CppCoreGuidelines.md
@@ -1048,7 +1048,7 @@ You can use the simplest "singleton" (so simple that it is often not considered 
 
 This is one of the most effective solutions to problems related to initialization and destruction order.
 In a multi-threaded environment the initialization of the static object does not introduce a race condition
-(unless you carelessly access a shared object from within its constructor). At destruction, the object is
+(unless you carelessly access a shared object from within its constructor). At program exit, the object is
 not destructed, so it is safe even in the face of access from un-joined threads.
 
 If you, as many do, define a singleton as a class for which only one object is created, functions like `myX` are not singletons, and this useful technique is not an exception to the no-singleton rule.

--- a/CppCoreGuidelines.md
+++ b/CppCoreGuidelines.md
@@ -1042,13 +1042,14 @@ You can use the simplest "singleton" (so simple that it is often not considered 
 
     X& myX()
     {
-        static X my_x {3};
-        return my_x;
+        static X* my_x = new X{3};
+        return *my_x;
     }
 
-This is one of the most effective solutions to problems related to initialization order.
+This is one of the most effective solutions to problems related to initialization and destruction order.
 In a multi-threaded environment the initialization of the static object does not introduce a race condition
-(unless you carelessly access a shared object from within its constructor).
+(unless you carelessly access a shared object from within its constructor). At destruction, the object is
+not destructed, so it is safe even in the face of access from un-joined threads.
 
 If you, as many do, define a singleton as a class for which only one object is created, functions like `myX` are not singletons, and this useful technique is not an exception to the no-singleton rule.
 


### PR DESCRIPTION
C++11 (and later) will synchronize on function-static object initialization, but will still allow un-joined threads to access the object after destruction during program teardown.  The better option is to heap allocat that initialization so that it isn't destructed during program shutdown, avoiding both the initialization AND shutdown races.