### PR TITLE
The vector was missing template arguments. Fixed.

### DIFF
--- a/CppCoreGuidelines.md
+++ b/CppCoreGuidelines.md
@@ -9120,7 +9120,7 @@ Simple code can be very fast. Optimizers sometimes do marvels with simple code
 
     // clear expression of intent, fast execution
     
-    vector v(100000);
+    vector<char> v(100000);
     
     for(auto& c : v)
         c = ~c;
@@ -9129,7 +9129,7 @@ Simple code can be very fast. Optimizers sometimes do marvels with simple code
 
     // intended to be faster, but is actually slower
     
-    vector v(100000);
+    vector<char> v(100000);
     
     for(size_t i=0; i<v.size(); i+=sizeof(uint64_t))
     {


### PR DESCRIPTION
The vector was missing template arguments. Fixed.
See #263 for the rationale.