### PR TITLE
fixed a typos because of zero-based indexing

### DIFF
--- a/CppCoreGuidelines.md
+++ b/CppCoreGuidelines.md
@@ -8247,10 +8247,10 @@ Readability. Error prevention. Efficiency.
     for (int i = 1; i < v.size(); ++i) // touches two elements: can't be a range-for
         cout << v[i] + v[i-1] << '\n';
 
-    for (int i = 1; i < v.size(); ++i) // possible side-effect: can't be a range-for
+    for (int i = 0; i < v.size(); ++i) // possible side-effect: can't be a range-for
         cout << f(&v[i]) << '\n';
 
-    for (int i = 1; i < v.size(); ++i) { // body messes with loop variable: can't be a range-for
+    for (int i = 0; i < v.size(); ++i) { // body messes with loop variable: can't be a range-for
         if (i % 2)
             ++i;	// skip even elements
         else


### PR DESCRIPTION
Another misunderstanding: how container can be modified (side-effect in a call of `f(&v[i])` ) if we passing only an address to element, not a address to container?