### PR TITLE
P.1: Minor fixes to the examples.

### DIFF
--- a/CppCoreGuidelines.md
+++ b/CppCoreGuidelines.md
@@ -387,7 +387,7 @@ A much clearer expression of intent would be:
         string val;
         cin >> val;
         // ...
-        auto p = find(v, val);  // better
+        auto p = find(begin(v), end(v), val);  // better
         // ...
     }
 

--- a/CppCoreGuidelines.md
+++ b/CppCoreGuidelines.md
@@ -370,7 +370,7 @@ The second version leaves the reader guessing and opens more possibilities for u
         string val;
         cin >> val;
         // ...
-        int index = 0;            // bad
+        int index = -1;            // bad
         for (int i = 0; i < v.size(); ++i)
             if (v[i] == val) {
                 index = i;


### PR DESCRIPTION
(1) The index result of a `std::find`-like loop needs to be initialized to `-1`, otherwise it's ambiguous as to whether `index == 0` means "first element" or "not found".
(2) We should still pass begin/end iterators to `std::find` (unless we're already using the ranges library?)