### PR TITLE
I.25: Marked `center` and `draw` as `const`.

### DIFF
--- a/CppCoreGuidelines.md
+++ b/CppCoreGuidelines.md
@@ -1726,8 +1726,8 @@ You just knew that `Shape` would turn up somewhere :-)
 
     class Shape {  // bad: interface class loaded with data
     public:
-        Point center() { return c; }
-        virtual void draw();
+        Point center() const { return c; }
+        virtual void draw() const;
         virtual void rotate(int);
         // ...
     private:
@@ -1740,8 +1740,8 @@ This will force every derived class to compute a center -- even if that's non-tr
 
     class Shape {    // better: Shape is a pure interface
     public:
-        virtual Point center() = 0;   // pure virtual function
-        virtual void draw() = 0;
+        virtual Point center() const = 0;   // pure virtual function
+        virtual void draw() const = 0;
         virtual void rotate(int) = 0;
         // ...
         // ... no data members ...


### PR DESCRIPTION
While it's not the point of the guideline, an accessor function `center` and a function like `draw` should still be marked `const`.