### PR TITLE
minor fixes to gh-pages

### DIFF
--- a/_includes/sidebar.html
+++ b/_includes/sidebar.html
@@ -14,6 +14,7 @@
         {% if page.name == "CppCoreGuidelines.md" %}
       <!-- Items have to be added manually until for now -->
       <a class="sidebar-nav-item active" href="#main">Top</a>
+      <a class="sidebar-nav-item active" href="#S-introduction">In: Introduction</a>
       <a class="sidebar-nav-item active" href="#S-philosophy">P: Philosophy</a>
       <a class="sidebar-nav-item active" href="#S-interfaces">I: Interfaces</a>
       <a class="sidebar-nav-item active" href="#S-functions">F: Functions</a>
@@ -31,7 +32,7 @@
       <a class="sidebar-nav-item active" href="#S-profile">PRO: Profiles</a>
       <a class="sidebar-nav-item active" href="#S-gsl">GSL: Guideline support library</a>
       <a class="sidebar-nav-item active" href="#S-faq">FAQ: Answers to frequently asked questions</a>
-      
+
       <a class="sidebar-nav-item active" href="#S-naming">NL: Naming and layout</a>
       <a class="sidebar-nav-item active" href="#S-performance">PER: Performance</a>
       <a class="sidebar-nav-item active" href="#S-not">N: Non-Rules and myths</a>
@@ -39,7 +40,7 @@
       <a class="sidebar-nav-item active" href="#S-libraries">Appendix A: Libraries</a>
       <a class="sidebar-nav-item active" href="#S-modernizing">Appendix B: Modernizing code</a>
       <a class="sidebar-nav-item active" href="#S-discussion">Appendix C: Discussion</a>
-      <a class="sidebar-nav-item active" href="#S-glossary">Appendix C: Glossary</a>
+      <a class="sidebar-nav-item active" href="#S-glossary">Glossary</a>
       <a class="sidebar-nav-item active" href="#S-unclassified">To-do: Unclassified proto-rules</a>
       <button id="button">Highlighting</button>
 

--- a/_includes/sidebar.html
+++ b/_includes/sidebar.html
@@ -48,7 +48,7 @@
 
       <a class="sidebar-nav-item active" href="CppCoreGuidelines.html">C++ Core Guidelines</a>
       <a class="sidebar-nav-item active" href="index.html">README</a>
-      <a class="sidebar-nav-item active" href="CONTRIBUTING.html">Contributing</a>
+      <a class="sidebar-nav-item active" href="CONTRIBUTING.md">Contributing</a>
       <a class="sidebar-nav-item active" href="LICENSE">License</a>
         {% endif %}
 

--- a/public/css/custom.css
+++ b/public/css/custom.css
@@ -74,7 +74,7 @@ h5:before {
     content: '\A'; white-space:pre-line;
 }
 
-p {
+h5 + p {
     display: inline;
 }
 


### PR DESCRIPTION
As discussed in #146, this changes the css hack to provide spacing between paragraphs.

An Alternative would be to delete that whole section in `custom.css` and have the h5 headers be above the text instead of left of it. I made this css hack initially only because the initial open-source version of the guidelines used that style:

"
**Note** Some note txt etc.
"

I am personally dispassionate about this style.

This PR als makes minor fixes to the sidebar navigation.