### PR TITLE
Don't mix future runtime customization constexpr.

### DIFF
--- a/CppCoreGuidelines.md
+++ b/CppCoreGuidelines.md
@@ -2081,10 +2081,10 @@ Don't try to make all functions `constexpr`. Most computation is best done at ru
 
 ##### Note
 
-Any API that may eventually become configurable or customizable at runtime
-should not be made `constexpr`. Such customization could not be evaluated by the
-compiler, and any `constexpr` functions that depend upon that API will have to
-be refactored or drop `constexpr`.
+Any API that may eventually depend on high-level runtime configuration or
+business logic should not be made `constexpr`. Such customization can not be
+evaluated by the compiler, and any `constexpr` functions that depend upon that
+API will have to be refactored or drop `constexpr`.
 
 ##### Enforcement
 

--- a/CppCoreGuidelines.md
+++ b/CppCoreGuidelines.md
@@ -2079,6 +2079,13 @@ This is usually a very good thing.
 
 Don't try to make all functions `constexpr`. Most computation is best done at run time.
 
+##### Note
+
+Any API that may eventually become configurable or customizable at runtime
+should not be made `constexpr`. Such customization could not be evaluated by the
+compiler, and any `constexpr` functions that depend upon that API will have to
+be refactored or drop `constexpr`.
+
 ##### Enforcement
 
 Impossible and unnecessary.


### PR DESCRIPTION
As discussed in https://github.com/isocpp/CppCoreGuidelines/issues/420