### PR TITLE
rewritten the CPL.1 as valid C

### DIFF
--- a/CppCoreGuidelines.md
+++ b/CppCoreGuidelines.md
@@ -13138,12 +13138,21 @@ C++ provides better type checking and more notational support.
 It provides better support for high-level programming and often generates faster code.
 
 ##### Example
-
-    char ch = 7;
-    void* pv = &ch;
-    int* pi = pv;   // not C++
-    *pi = 999;      // overwrite sizeof(int) bytes near &ch
-
+    struct dataX{
+        char temperature;
+        char windspeed;
+    }
+    struct dataY{
+        int id;
+        double weight;
+    }
+    int main(){
+        struct dataX x;
+        void* ptrX = &x;
+        struct dataY* = ptrX; // not C++
+        dataY.temperature=20;// overwrite sizeof(int) bytes near &temperature, 
+        //thus corrupting "windspeed" and other data or structure padding
+    }
 ##### Enforcement
 
 Use a C++ compiler.


### PR DESCRIPTION
The example casted a pointer between to a more strict aligned type which is undefined behaviour . 
So i changed the example to use structs instead of primitives. This forces the compiler to allign the data structure and thus makes it valid C. 

https://github.com/isocpp/CppCoreGuidelines/issues/542

https://www.securecoding.cert.org/confluence/display/c/EXP36-C.+Do+not+cast+pointers+into+more+strictly+aligned+pointer+types