### PR TITLE
C.33_610: changed owner<T>* to owner<T*> per issue 610

### DIFF
--- a/CppCoreGuidelines.md
+++ b/CppCoreGuidelines.md
@@ -4018,7 +4018,7 @@ The default copy operation will just copy the `p1.p` into `p2.p` leading to a do
 
     template<typename T>
     class Smart_ptr3 {
-        owner<T>* p;   // OK: explicit about ownership of *p
+        owner<T*> p;   // OK: explicit about ownership of *p
         // ...
     public:
         // ...


### PR DESCRIPTION
Did not change the owner<T> to owner<T*> in the Enforcement section.  
The document is littered with  owner<T> references in the text.  So assuming this 
is the intended style guideline for now.