### PR TITLE
F.7:  Fixed note about noexcept constexpr functions (per #616)

### DIFF
--- a/CppCoreGuidelines.md
+++ b/CppCoreGuidelines.md
@@ -2189,7 +2189,7 @@ The C++ standard library does that implicitly for all functions in the C standar
 
 ##### Note
 
-`constexpr` functions cannot throw, so you don't need to use `noexcept` for those.
+This also applies to `constexpr` functions, which can throw exceptions just like normal functions when evaluated during runtime.
 
 ##### Example
 


### PR DESCRIPTION
As discussed in issue #616, constexpr functions can throw exceptions just like normal functions when evaluated during runtime.