### PR TITLE
use proper argument for creation of span from array

### DIFF
--- a/CppCoreGuidelines.md
+++ b/CppCoreGuidelines.md
@@ -15422,7 +15422,7 @@ Pointers should not be used as arrays. `span` is a bounds-checked, safe alternat
         span<int> av = a;
 
         g(av.data(), av.length());   // OK, if you have no choice
-        g1(a);                      // OK -- no decay here, instead use implicit span ctor
+        g1(a);                       // OK -- no decay here, instead use implicit span ctor
     }
 
 ##### Enforcement

--- a/CppCoreGuidelines.md
+++ b/CppCoreGuidelines.md
@@ -15422,7 +15422,7 @@ Pointers should not be used as arrays. `span` is a bounds-checked, safe alternat
         span<int> av = a;
 
         g(av.data(), av.length());   // OK, if you have no choice
-        g1(av);                      // OK -- no decay here, instead use implicit span ctor
+        g1(a);                      // OK -- no decay here, instead use implicit span ctor
     }
 
 ##### Enforcement


### PR DESCRIPTION
I believe the intention is to call ```constexpr span(T (&arr)[N])```, not the copy c-tor in this example.