### PR TITLE
Fix Travis CI by reverting "Better comment for implicit conversion example"

### DIFF
--- a/CppCoreGuidelines.md
+++ b/CppCoreGuidelines.md
@@ -15422,7 +15422,7 @@ Pointers should not be used as arrays. `span` is a bounds-checked, safe alternat
         span<int> av = a;
 
         g(av.data(), av.length());   // OK, if you have no choice
-        g1(a);                       // OK -- no decay here, instead use implicit span ctor from n-dimensions static array
+        g1(a);                       // OK -- no decay here, instead use implicit span ctor
     }
 
 ##### Enforcement


### PR DESCRIPTION
This fixes Travis CI failure "Lines should be <= 100 characters long  [whitespace/line_length] [2]" by reverting commit c2f54b5ed1cd72523ccdf454e013e2b7df177955.

Besides, "static array" is not a thing