### PR TITLE
Remove note in NL.17 about naming

### DIFF
--- a/CppCoreGuidelines.md
+++ b/CppCoreGuidelines.md
@@ -16829,10 +16829,6 @@ The `{` for a `class` and a `struct` in *not* on a separate line, but the `{` fo
 
 ##### Note
 
-Capitalize the names of your user-defined types to distinguish them from standards-library types.
-
-##### Note
-
 Do not capitalize function names.
 
 ##### Enforcement


### PR DESCRIPTION
This rule is about indentation, and conflicts with choices offered in NL.8