### PR TITLE
T.44: Added `s` suffix to string literal

### DIFF
--- a/CppCoreGuidelines.md
+++ b/CppCoreGuidelines.md
@@ -14134,7 +14134,7 @@ Note that C++17 will make this rule redundant by allowing the template arguments
 [Template parameter deduction for constructors (Rev. 3)](http://www.open-std.org/jtc1/sc22/wg21/docs/papers/2016/p0091r1.html).
 For example:
 
-    tuple t1 = {1, "Hamlet", 3.14}; // deduced: tuple<int, string, double>
+    tuple t1 = {1, "Hamlet"s, 3.14}; // deduced: tuple<int, string, double>
 
 ##### Enforcement
 


### PR DESCRIPTION
As written, the type for "Hamlet" without the `s` suffix will be deduced to `const char*` instead of the intended `std::string`, see example earlier for auto deduced `std::string` for "Ophelia"s with the `s` suffix.