### PR TITLE
stricter cpplint checks

### DIFF
--- a/scripts/python/Makefile.in
+++ b/scripts/python/Makefile.in
@@ -14,5 +14,5 @@ CXX_LINT := ${CXX_SRCS:.cpp=.lint}
 cpplint-all: $(CXX_LINT)
 
 %.lint: %.cpp
-	@python ../../python/cpplint.py --verbose=0 --linelength=100 --filter=-legal/copyright,-build/include_order,-build/c++11,-build/namespaces,-build/class,-build/include,-build/include_subdir,-readability/inheritance,-readability/function,-readability/casting,-readability/namespace,-readability/alt_tokens,-readability/braces,-readability/fn_size,-whitespace/comments,-whitespace/braces,-whitespace/empty_loop_body,-whitespace/indent,-whitespace/newline,-runtime/explicit,-runtime/arrays,-runtime/int,-runtime/references,-runtime/string,-runtime/operator $< || (cat $< | nl -ba | grep -v 'md-split' && false)
+	@python ../../python/cpplint.py --verbose=0 --linelength=100 --filter=-legal/copyright,-build/include_order,-build/namespaces,-build/include,-build/include_subdir,-readability/inheritance,-readability/casting,-readability/namespace,-readability/alt_tokens,-readability/braces,-readability/fn_size,-whitespace/comments,-whitespace/braces,-whitespace/empty_loop_body,-whitespace/indent,-whitespace/newline,-runtime/explicit,-runtime/arrays,-runtime/int,-runtime/references,-runtime/string,-runtime/operator $< || (cat $< | nl -ba | grep -v 'md-split' && false)
 


### PR DESCRIPTION
Now, allowing the [build/c++11] and [build/class] cpplint categories does not find issues anymore, so I see no reason to ignore these categories in the travis checks.