### PR TITLE
Fix text mistake

### DIFF
--- a/CppCoreGuidelines.md
+++ b/CppCoreGuidelines.md
@@ -11280,7 +11280,7 @@ Consider:
     template <class ForwardIterator, class T>
     bool binary_search(ForwardIterator first, ForwardIterator last, const T& val);
 
-`binary_search(begin(c),end(c),7)` will tell you whether `7` is in `c` or not.
+`binary_search(begin(c) ,end(c) ,7)` will tell you whether `7` is in `c` or not.
 However, it will not tell you where that `7` is or whether there are more than one `7`.
 
 Sometimes, just passing the minimal amount of information back (here, `true` or `false`) is sufficient, but a good interface passes
@@ -11299,7 +11299,7 @@ However, `lower_bound` still doesn't return enough information for all uses, so 
 
 `equal_range` returns a `pair` of iterators specifying the first and one beyond last match.
 
-    auto r = equal_range(begin(c), end(c),7);
+    auto r = equal_range(begin(c), end(c) ,7);
     for (auto p = r.first(); p != r.second(), ++p)
         cout << *p << '\n';
 

--- a/CppCoreGuidelines.md
+++ b/CppCoreGuidelines.md
@@ -11514,7 +11514,10 @@ There are several ways that this example could be made safe for a multi-threaded
 * Refuse to build and/or run in a multi-threaded environment.
 * Provide two implementations, one which is used in single-threaded environments and another which is used in multi-threaded environments.
 
- Code that is never run in a multi-threaded environment.
+##### Exception
+
+Code that is never run in a multi-threaded environment.
+
 Be careful: there are many examples where code that was "known" to never run in a multi-threaded program
 was run as part of a multi-threaded program. Often years later.
 Typically, such programs lead to a painful effort to remove data races.


### PR DESCRIPTION
Hi, I believe when switching from 

    *Exception*

to

    #### Exception

A mistake was made in 4d7b1d7.

See the part of the diff:

```
@@ -11283,7 +11330,7 @@ There are several ways that this example could be made safe for a multi-threaded
 * Refuse to build and/or run in a multi-threaded environment.
 * Provide two implementations, one which is used in single-threaded environments and another which is used in multi-threaded environments.
 
-**Exception**: Code that is never run in a multi-threaded environment.
+ Code that is never run in a multi-threaded environment.
```
