### PR TITLE
Update C.128 to remove override from destructors

### DIFF
--- a/CppCoreGuidelines.md
+++ b/CppCoreGuidelines.md
@@ -6103,7 +6103,7 @@ Readability.
 Detection of mistakes.
 Writing explicit `virtual`, `override`, or `final` is self-documenting and enables the compiler to catch mismatch of types and/or names between base and derived classes. However, writing more than one of these three is both redundant and a potential source of errors.
 
-Use `virtual` only when declaring a new virtual function. Use `override` only when declaring an overrider. Use `final` only when declaring an final overrider.
+Use `virtual` only when declaring a new virtual function. Use `override` only when declaring an overrider. Use `final` only when declaring an final overrider. If a base class destructor is declared `virtual`, derived class destructors should neither be declared `virtual` nor `override`. 
 
 ##### Example, bad
 


### PR DESCRIPTION
Clang Tidy has a a check called (modernize-use-override) that explicitly verifies that `override` be placed on destructors of derived classes whose base class is `virtual` as seen [here](https://github.com/Microsoft/clang-tools-extra/blob/master/test/clang-tidy/modernize-use-override.cpp#L48). This issue was brought up by @jaredgrubb in the following [ticket](https://github.com/isocpp/CppCoreGuidelines/issues/721#issuecomment-246627077) and was also seen [here](https://github.com/Bareflank/hypervisor/issues/208) as well. @gdr-at-ms closed the ticket stating that the C++ Core Guideline Editors have decided that `override` should not be placed on destructors, but the documentation makes no mention of this decision. The following PR addresses this issue. With the documentation updated, an issue ticket can be generated for Clang Tidy to have the destructor check modified to reflect the C++ Core Guidance.