### PR TITLE
Fixes incorrect order of type and function name in the naming scheme example

### DIFF
--- a/CppCoreGuidelines.md
+++ b/CppCoreGuidelines.md
@@ -16876,7 +16876,7 @@ This is not evil.
 
 ##### Example
 
-    sqrt double(double x);   // return the square root of x; x must be non-negative
+    double sqrt(double x);   // return the square root of x; x must be non-negative
 
     int length(const char* p);  // return the number of characters in a zero-terminated C-style string
 


### PR DESCRIPTION
### NL.7: Make the length of a name roughly proportional to the length of its scope

`https://isocpp.github.io/CppCoreGuidelines/CppCoreGuidelines#Rl-name-length`

Example: `sqrt double(double x);   // return the square root of x; x must be non-negative`, changed to `double sqrt(double x);   // return the square root of x; x must be non-negative`