### PR TITLE
In.force: wording

### DIFF
--- a/CppCoreGuidelines.md
+++ b/CppCoreGuidelines.md
@@ -233,8 +233,9 @@ Also, suggest an improvement.
 
 ## <a name="SS-force"></a>In.force: Enforcement
 
-Rules with no enforcement are unmanageable for large code bases.
-Enforcement of all rules is possible only for a small weak set of rules or for a specific user community.
+Rules without mechanical enforcement are unmanageable for large code bases.
+Enforcement of all rules is possible only for a specific user community.
+Mechanical enforcement is possible only for a small weak set of rules.
 
 * But we want lots of rules, and we want rules that everybody can use.
 * But different people have different needs.


### PR DESCRIPTION
> Rules with no enforcement are unmanageable for large code bases.

An unenforceable rule isn't, by definition, a rule. I believe it meant to be rules without mechanical enforcement.

> Enforcement of all rules is possible only for a small weak set of rules or for a specific user community.

The first part of the disjunction doesn't make sense. It has the problem mentioned above, and also mentions that "all is only a part". Thus, I divided it and applied the same fix as above to the first part.