### PR TITLE
Exception of CP.100 refined to include the "sequentially consistent memory model" only

### DIFF
--- a/CppCoreGuidelines.md
+++ b/CppCoreGuidelines.md
@@ -12570,7 +12570,7 @@ Read up on the ABA problem.
 
 ##### Exception
 
-[Atomic variables](#???) can be used simply and safely.
+[Atomic variables](#???) can be used simply and safely, as long as you are using the sequentially consistent memory model (memory_order_seq_cst), which is the default.
 
 ##### Note
 

--- a/scripts/hunspell/isocpp.dic
+++ b/scripts/hunspell/isocpp.dic
@@ -95,6 +95,7 @@ cpp
 cpp98
 CppCon
 CRTP
+cst
 cstdarg
 cstring
 cstylecast


### PR DESCRIPTION
Atomic variables are safe with the sequentially consistent memory model (**memory_order_seq_cst**) only. Weakly ordered atomics cannot be considered safe for mainstream use. The exception clause of CP.100 refined.
