### PR TITLE
T.84 Correction of Example: Change type of suc and pre to Link_base

### DIFF
--- a/CppCoreGuidelines.md
+++ b/CppCoreGuidelines.md
@@ -15519,8 +15519,8 @@ Avoid code bloat.
 It could be a base class:
 
     struct Link_base {   // stable
-        Link* suc;
-        Link* pre;
+        Link_base* suc;
+        Link_base* pre;
     };
 
     template<typename T>   // templated wrapper to add type safety


### PR DESCRIPTION
The members of Link_base in this example have to be of type Link_base, since Link is not know at this place and one wants to be independent from Link<T>.
