### PR TITLE
T.84: example fix - Link struct initialization.

### DIFF
--- a/CppCoreGuidelines.md
+++ b/CppCoreGuidelines.md
@@ -15538,7 +15538,7 @@ It could be a base class:
     template<typename T>
     class List : List_base {
     public:
-        void put_front(const T& e) { add_front(new Link<T>{e}); }   // implicit cast to Link_base
+        void put_front(const T& e) { add_front(new Link<T>{{}, e}); }   // implicit cast to Link_base
         T& front() { static_cast<Link<T>*>(first).val; }   // explicit cast back to Link<T>
         // ...
     };


### PR DESCRIPTION
[T.84](https://github.com/isocpp/CppCoreGuidelines/blob/master/CppCoreGuidelines.md#t84-use-a-non-template-core-implementation-to-provide-an-abi-stable-interface) example performs incorrect `Link` struct initialization in `put_front` method:
`void put_front(const T& e) { add_front(new Link<T>{e}); }`

`Link` is derived from `Link_base` so that initialization is ill-formed in C++14 and will try to initialize `Link_base` from `e` in C++17 according to [P0017R1](http://www.open-std.org/jtc1/sc22/wg21/docs/papers/2015/p0017r1.html).

This pull request fixes the issue.
