### PR TITLE
fix c.127 example issue.

### DIFF
--- a/CppCoreGuidelines.md
+++ b/CppCoreGuidelines.md
@@ -6083,7 +6083,7 @@ A class with a virtual function is usually (and in general) used via a pointer t
 
     void use()
     {
-        auto p = make_unique<D>();
+        unique_ptr<B> p = make_unique<D>();
         // ...
     } // calls B::~B only, leaks the string
 


### PR DESCRIPTION
auto will deduce as unique_ptr<D> and the correct destructor will call. Anyway, this should be a bad example.