### PR TITLE
Fix ES.56 title in the ES table of contents to match its actual title

### DIFF
--- a/CppCoreGuidelines.md
+++ b/CppCoreGuidelines.md
@@ -8736,7 +8736,7 @@ Expression rules:
 * [ES.49: If you must use a cast, use a named cast](#Res-casts-named)
 * [ES.50: Don't cast away `const`](#Res-casts-const)
 * [ES.55: Avoid the need for range checking](#Res-range-checking)
-* [ES.56: Avoid `std::move()` in application code](#Res-move)
+* [ES.56: Write `std::move()` only when you need to explicitly move an object to another scope](#Res-move)
 * [ES.60: Avoid `new` and `delete` outside resource management functions](#Res-new)
 * [ES.61: Delete arrays using `delete[]` and non-arrays using `delete`](#Res-del)
 * [ES.62: Don't compare pointers into different arrays](#Res-arr2)


### PR DESCRIPTION
When the title (and content) of ES.56 was changed by https://github.com/isocpp/CppCoreGuidelines/commit/1b3efdf1e8ed7edc6ba2dc6ea539ea104d84e1b6  its entry in the ES ToC wasn't, this brings them back in sync.