### PR TITLE
C.127 should not claim that there is a defined behavior

### DIFF
--- a/CppCoreGuidelines.md
+++ b/CppCoreGuidelines.md
@@ -6077,7 +6077,7 @@ A class with a virtual function is usually (and in general) used via a pointer t
         // ... no user-written destructor, defaults to public nonvirtual ...
     };
 
-    // bad: class with a resource derived from a class without a virtual destructor
+    // bad: derived from a class without a virtual destructor
     struct D : B {
         string s {"default"};
     };
@@ -6086,7 +6086,7 @@ A class with a virtual function is usually (and in general) used via a pointer t
     {
         auto p = make_unique<D>();
         // ...
-    } // calls B::~B only, leaks the string
+    } // undefined behavior. May call B::~B only and leak the string
 
 ##### Note
 


### PR DESCRIPTION
The comments in the example in C.127 support the popular misconception that it's only bad to destroy a polymorphic object through base with non-virtual destructor if there are some resources in the derived object that would be leaked.

[[expr.delete]/3](http://eel.is/c++draft/expr.delete#3)  is very explicit that it is undefined behavior. See also [Stack Overflow](http://stackoverflow.com/questions/2100644/will-using-delete-with-a-base-class-pointer-cause-a-memory-leak) 
