### PR TITLE
Build related fixes 

### DIFF
--- a/CppCoreGuidelines.md
+++ b/CppCoreGuidelines.md
@@ -1034,7 +1034,7 @@ We typically have better things to do than repeatedly do routine tasks.
 
 ##### Example
 
-Run a static analyser to verify that your code follows the guidelines you want it to follow.
+Run a static analyzer to verify that your code follows the guidelines you want it to follow.
 
 ##### Note
 
@@ -2396,7 +2396,7 @@ The C++ standard library does that implicitly for all functions in the C standar
 
 ##### Note
 
-`constexpr` functions can when evaluated at run time, so yu may need `noexcept` for some of those.
+`constexpr` functions can when evaluated at run time, so you may need `noexcept` for some of those.
 
 ##### Example
 
@@ -3742,10 +3742,10 @@ This rule becomes even better if C++ gets ["uniform function call"](http://www.o
 
 ##### Exception
 
-The language requires `virtual` funtions to be members, and not all `virtual` functions directly access data.
+The language requires `virtual` functions to be members, and not all `virtual` functions directly access data.
 In particular, members of an abstract class rarely do.
 
-Note [multimethods](https://parasol.tamu.edu/~yuriys/papers/OMM10.pdf).
+Note [multi-methods](https://parasol.tamu.edu/~yuriys/papers/OMM10.pdf).
 
 ##### Exception
 

--- a/CppCoreGuidelines.md
+++ b/CppCoreGuidelines.md
@@ -1067,7 +1067,7 @@ So, if a suitable library exists for your application domain, use it.
 
 ##### Example
 
-    std::sort(begin(v),end(v),std::greater<>());
+    std::sort(begin(v), end(v), std::greater<>());
 
 Unless you are an expert in sorting algorithms and have plenty of time,
 this is more likely to be correct and to run faster than anything you write for a specific application.
@@ -9485,7 +9485,7 @@ Assuming that there is a logical connection between `i` and `j`, that connection
 
 Obviously, what we really would like is a construct that initialized n variables from a `tuple`. For example:
 
-    auto [i,j] = make_related_widgets(cond);    // C++17, not C++14
+    auto [i, j] = make_related_widgets(cond);    // C++17, not C++14
 
 Today, we might approximate that using `tie()`:
 

--- a/CppCoreGuidelines.md
+++ b/CppCoreGuidelines.md
@@ -16553,10 +16553,10 @@ Doing so takes away an `#include`r's ability to effectively disambiguate and to 
     // user.cpp
     #include "bad.h"
     
-    bool copy( /*... some parameters ...*/);    // some function that happens to be named copy
+    bool copy(/*... some parameters ...*/);    // some function that happens to be named copy
 
     int main() {
-        copy( /*...*/ );    // now overloads local ::copy and std::copy, could be ambiguous
+        copy(/*...*/);    // now overloads local ::copy and std::copy, could be ambiguous
     }
 
 ##### Enforcement

--- a/CppCoreGuidelines.md
+++ b/CppCoreGuidelines.md
@@ -11976,13 +11976,13 @@ There are many tools "out there", both commercial and open-source tools, both re
 Unfortunately people's needs and constraints differ so dramatically that we cannot make specific recommendations,
 but we can mention:
 
- * Static enforcement tools: both [clang](http://clang.llvm.org/docs/ThreadSafetyAnalysis.html)
- and some older versions of [GCC](https://gcc.gnu.org/wiki/ThreadSafetyAnnotation)
- have some support for static annotation of thread safety properties.
- Consistent use of this technique turns many classes of thread-safety errors into compile-time errors.
- The annotations are generally local (marking a particular member variable as guarded by a particular mutex),
- and are usually easy to learn. However, as with many static tools, it can often present false negatives;
- cases that should have been caught but were allowed.
+* Static enforcement tools: both [clang](http://clang.llvm.org/docs/ThreadSafetyAnalysis.html)
+and some older versions of [GCC](https://gcc.gnu.org/wiki/ThreadSafetyAnnotation)
+have some support for static annotation of thread safety properties.
+Consistent use of this technique turns many classes of thread-safety errors into compile-time errors.
+The annotations are generally local (marking a particular member variable as guarded by a particular mutex),
+and are usually easy to learn. However, as with many static tools, it can often present false negatives;
+cases that should have been caught but were allowed.
 
 * dynamic enforcement tools: Clang's [Thread Sanitizer](http://clang.llvm.org/docs/ThreadSanitizer.html) (aka TSAN)
 is a powerful example of dynamic tools: it changes the build and execution of your program to add bookkeeping on memory access,
@@ -19408,6 +19408,7 @@ A relatively informal definition of terms used in the guidelines
 This is our to-do list.
 Eventually, the entries will become rules or parts of rules.
 Alternatively, we will decide that no change is needed and delete the entry.
+
 * No long-distance friendship
 * Should physical design (what's in a file) and large-scale design (libraries, groups of libraries) be addressed?
 * Namespaces

--- a/CppCoreGuidelines.md
+++ b/CppCoreGuidelines.md
@@ -12471,8 +12471,7 @@ Thread creation is expensive.
         // process
     }
 
-    void 
-    (istream& is)
+    void master(istream& is)
     {
         for (Message m; is >> m; )
             run_list.push_back(new thread(worker, m));

--- a/scripts/hunspell/isocpp.dic
+++ b/scripts/hunspell/isocpp.dic
@@ -277,6 +277,8 @@ Meyers15
 Meyers96
 Meyers97
 microbenchmarks
+mixin
+mixins
 modify1
 modify2
 moredata
@@ -510,6 +512,7 @@ unenforceable
 uninit
 uniqueptrparam
 unittest
+unittests
 unnamed2
 use1
 users'


### PR DESCRIPTION
This is just a minor bit of cleanup in order to get travis closer to compiling.  With these changes the only two remaining issues I see are:

  14012:15-14012:58  warning  Don’t pad `emphasis` with inner spaces  no-inline-padding
  14013:21-14013:45  warning  Don’t pad `emphasis` with inner spaces  no-inline-padding

These don't appear to be resolvable without more significant rewriting.  Lines 14032-33 have very similar content but don't result in this error where they are currently located.  If you move them up to this location then they do.

If you wrap the 14012-13 lines inside the header blocks (###) like 14032-33 then the error goes away.
