### PR TITLE
Additional guidance around casts:

### DIFF
--- a/CppCoreGuidelines.md
+++ b/CppCoreGuidelines.md
@@ -19400,9 +19400,9 @@ An implementation of this profile shall recognize the following patterns in sour
 Type safety profile summary:
 
 * <a name="Pro-type-avoidcasts"></a>Type.1: [Avoid casts](#Res-casts):  
-<a name="Pro-type-reinterpretcast">a.</a>Don't use `reinterpret_cast`; A strict version of [Avoid casts](#Res-casts) and [prefer named casts](#Res-casts-named).  
-<a name="Pro-type-arithmeticcast">b.</a>Don't a `static_cast` for arithmetic types; A strict version of [Avoid casts](#Res-casts) and [prefer named casts](#Res-casts-named).  
-<a name="Pro-type-unnecessarycast">c.</a>Don't use pointer unnecessary pointer casts; A strict version of [Avoid casts](#Res-casts)  
+<a name="Pro-type-reinterpretcast">a. </a>Don't use `reinterpret_cast`; A strict version of [Avoid casts](#Res-casts) and [prefer named casts](#Res-casts-named).  
+<a name="Pro-type-arithmeticcast">b. </a>Don't a `static_cast` for arithmetic types; A strict version of [Avoid casts](#Res-casts) and [prefer named casts](#Res-casts-named).  
+<a name="Pro-type-unnecessarycast">c. </a>Don't use pointer unnecessary pointer casts; A strict version of [Avoid casts](#Res-casts)  
 * <a name="Pro-type-downcast"></a>Type.2: Don't use `static_cast` to downcast:
 [Use `dynamic_cast` instead](#Rh-dynamic_cast).
 * <a name="Pro-type-constcast"></a>Type.3: Don't use `const_cast` to cast away `const` (i.e., at all):

--- a/CppCoreGuidelines.md
+++ b/CppCoreGuidelines.md
@@ -11602,7 +11602,8 @@ Surprised? I'm just glad I didn't crash the program.
 
 ##### Note
 
-Programmer who write casts typically assumes that they know what they are doing.
+Programmers who write casts typically assume that they know what they are doing, 
+or that writing a cast makes the program "easier to read".
 In fact, they often disable the general rules for using values.
 Overload resolution and template instantiation usually pick the right function if there is a right function to pick.
 If there is not, maybe there ought to be, rather than applying a local fix (cast).
@@ -11623,16 +11624,14 @@ Casts are widely (mis) used. Modern C++ has constructs that eliminate the need f
 
 * Use templates
 * Use `std::variant`
-
+* Rely on the well defined, safe, implicit conversions between pointer types
 
 ##### Enforcement
 
 * Force the elimination of C-style casts
-* Warn against named casts
-* Warn against unnecessary casts.
 * Warn if there are many functional style casts (there is an obvious problem in quantifying 'many').
 * The [type profile](#Pro-type-reinterpretcast) bans `reinterpret_cast`.
-
+* Warn against [unnecessary pointer casts](#Pro-type-unnecessarycast).
 
 ### <a name="Res-casts-named"></a>ES.49: If you must use a cast, use a named cast
 
@@ -11694,6 +11693,7 @@ for example.)
 
 * Flag C-style and functional casts.
 * The [type profile](#Pro-type-reinterpretcast) bans `reinterpret_cast`.
+* The [type profile](#Pro-type-arithmeticcast) warns when using `static_cast` between arithmetic types.
 
 ### <a name="Res-casts-const"></a>ES.50: Don't cast away `const`
 
@@ -19399,8 +19399,10 @@ An implementation of this profile shall recognize the following patterns in sour
 
 Type safety profile summary:
 
-* <a name="Pro-type-reinterpretcast"></a>Type.1: Don't use `reinterpret_cast`:
-A strict version of [Avoid casts](#Res-casts) and [prefer named casts](#Res-casts-named).
+* <a name="Pro-type-avoidcasts"></a>Type.1: [Avoid casts](#Res-casts):
+    * <a name="Pro-type-reinterpretcast"></a>Don't use `reinterpret_cast`; A strict version of [Avoid casts](#Res-casts) and [prefer named casts](#Res-casts-named).
+    * <a name="Pro-type-arithmeticcast"></a>Don't a `static_cast` for arithmetic types; A strict version of [Avoid casts](#Res-casts) and [prefer named casts](#Res-casts-named).
+    * <a name="Pro-type-unnecessarycast"></a>Don't use pointer unnecessary pointer casts; A strict version of [Avoid casts](#Res-casts)
 * <a name="Pro-type-downcast"></a>Type.2: Don't use `static_cast` to downcast:
 [Use `dynamic_cast` instead](#Rh-dynamic_cast).
 * <a name="Pro-type-constcast"></a>Type.3: Don't use `const_cast` to cast away `const` (i.e., at all):

--- a/CppCoreGuidelines.md
+++ b/CppCoreGuidelines.md
@@ -11235,6 +11235,7 @@ If you feel the need for a lot of casts, there may be a fundamental design probl
 * Force the elimination of C-style casts
 * Warn against named casts
 * Warn if there are many functional style casts (there is an obvious problem in quantifying 'many').
+* Warn against unnecessary casts.
 
 ### <a name="Res-casts-named"></a>ES.49: If you must use a cast, use a named cast
 
@@ -11287,7 +11288,8 @@ for example.)
 
 ##### Enforcement
 
-Flag C-style and functional casts.
+* Flag C-style and functional casts.
+* Suggest brace initialization or gsl::narrow_cast instead of named casts on arithmetic types.
 
 ### <a name="Res-casts-const"></a>ES.50: Don't cast away `const`
 
@@ -18570,7 +18572,9 @@ Use of these casts can violate type safety and cause the program to access a var
 
 ##### Enforcement
 
-Issue a diagnostic for any use of `reinterpret_cast`. To fix: Consider using a `variant` instead.
+* Issue a diagnostic for any use of `reinterpret_cast`. To fix: Consider using a `variant` instead.
+* Issue a separate diagnostic for any reinterpret_cast to void*.  To fix: Remove the cast and allow the implicit type conversion.
+* Issue a separate diagnostic for any reinterpret_cast from void*.  To fix: Use static_cast instead
 
 ### <a name="Pro-type-downcast"></a>Type.2: Don't use `static_cast` downcasts. Use `dynamic_cast` instead.
 

--- a/CppCoreGuidelines.md
+++ b/CppCoreGuidelines.md
@@ -19399,12 +19399,10 @@ An implementation of this profile shall recognize the following patterns in sour
 
 Type safety profile summary:
 
-* <a name="Pro-type-avoidcasts"></a>Type.1: [Avoid casts](#Res-casts):
-    
-    * <a name="Pro-type-reinterpretcast"></a>Don't use `reinterpret_cast`; A strict version of [Avoid casts](#Res-casts) and [prefer named casts](#Res-casts-named).
-    * <a name="Pro-type-arithmeticcast"></a>Don't a `static_cast` for arithmetic types; A strict version of [Avoid casts](#Res-casts) and [prefer named casts](#Res-casts-named).
-    * <a name="Pro-type-unnecessarycast"></a>Don't use pointer unnecessary pointer casts; A strict version of [Avoid casts](#Res-casts)
-    
+* <a name="Pro-type-avoidcasts"></a>Type.1: [Avoid casts](#Res-casts): 
+<a name="Pro-type-reinterpretcast">a.</a>Don't use `reinterpret_cast`; A strict version of [Avoid casts](#Res-casts) and [prefer named casts](#Res-casts-named).
+<a name="Pro-type-arithmeticcast">b.</a>Don't a `static_cast` for arithmetic types; A strict version of [Avoid casts](#Res-casts) and [prefer named casts](#Res-casts-named).
+<a name="Pro-type-unnecessarycast">c.</a>Don't use pointer unnecessary pointer casts; A strict version of [Avoid casts](#Res-casts)
 * <a name="Pro-type-downcast"></a>Type.2: Don't use `static_cast` to downcast:
 [Use `dynamic_cast` instead](#Rh-dynamic_cast).
 * <a name="Pro-type-constcast"></a>Type.3: Don't use `const_cast` to cast away `const` (i.e., at all):

--- a/CppCoreGuidelines.md
+++ b/CppCoreGuidelines.md
@@ -19399,10 +19399,10 @@ An implementation of this profile shall recognize the following patterns in sour
 
 Type safety profile summary:
 
-* <a name="Pro-type-avoidcasts"></a>Type.1: [Avoid casts](#Res-casts): 
-<a name="Pro-type-reinterpretcast">a.</a>Don't use `reinterpret_cast`; A strict version of [Avoid casts](#Res-casts) and [prefer named casts](#Res-casts-named).
-<a name="Pro-type-arithmeticcast">b.</a>Don't a `static_cast` for arithmetic types; A strict version of [Avoid casts](#Res-casts) and [prefer named casts](#Res-casts-named).
-<a name="Pro-type-unnecessarycast">c.</a>Don't use pointer unnecessary pointer casts; A strict version of [Avoid casts](#Res-casts)
+* <a name="Pro-type-avoidcasts"></a>Type.1: [Avoid casts](#Res-casts):  
+<a name="Pro-type-reinterpretcast">a.</a>Don't use `reinterpret_cast`; A strict version of [Avoid casts](#Res-casts) and [prefer named casts](#Res-casts-named).  
+<a name="Pro-type-arithmeticcast">b.</a>Don't a `static_cast` for arithmetic types; A strict version of [Avoid casts](#Res-casts) and [prefer named casts](#Res-casts-named).  
+<a name="Pro-type-unnecessarycast">c.</a>Don't use pointer unnecessary pointer casts; A strict version of [Avoid casts](#Res-casts)  
 * <a name="Pro-type-downcast"></a>Type.2: Don't use `static_cast` to downcast:
 [Use `dynamic_cast` instead](#Rh-dynamic_cast).
 * <a name="Pro-type-constcast"></a>Type.3: Don't use `const_cast` to cast away `const` (i.e., at all):

--- a/CppCoreGuidelines.md
+++ b/CppCoreGuidelines.md
@@ -19400,9 +19400,11 @@ An implementation of this profile shall recognize the following patterns in sour
 Type safety profile summary:
 
 * <a name="Pro-type-avoidcasts"></a>Type.1: [Avoid casts](#Res-casts):
+    
     * <a name="Pro-type-reinterpretcast"></a>Don't use `reinterpret_cast`; A strict version of [Avoid casts](#Res-casts) and [prefer named casts](#Res-casts-named).
     * <a name="Pro-type-arithmeticcast"></a>Don't a `static_cast` for arithmetic types; A strict version of [Avoid casts](#Res-casts) and [prefer named casts](#Res-casts-named).
     * <a name="Pro-type-unnecessarycast"></a>Don't use pointer unnecessary pointer casts; A strict version of [Avoid casts](#Res-casts)
+    
 * <a name="Pro-type-downcast"></a>Type.2: Don't use `static_cast` to downcast:
 [Use `dynamic_cast` instead](#Rh-dynamic_cast).
 * <a name="Pro-type-constcast"></a>Type.3: Don't use `const_cast` to cast away `const` (i.e., at all):

--- a/CppCoreGuidelines.md
+++ b/CppCoreGuidelines.md
@@ -11620,7 +11620,7 @@ If you feel the need for a lot of casts, there may be a fundamental design probl
 
 ##### Alternatives
 
-Casts are widely (mis) used. Modern C++ has constructs that eliminate the need for casts in many contexts, such as
+Casts are widely (mis) used. Modern C++ has rules and constructs that eliminate the need for casts in many contexts, such as
 
 * Use templates
 * Use `std::variant`
@@ -11629,9 +11629,10 @@ Casts are widely (mis) used. Modern C++ has constructs that eliminate the need f
 ##### Enforcement
 
 * Force the elimination of C-style casts
-* Warn if there are many functional style casts (there is an obvious problem in quantifying 'many').
+* Warn if there are many functional style casts (there is an obvious problem in quantifying 'many')
 * The [type profile](#Pro-type-reinterpretcast) bans `reinterpret_cast`.
-* Warn against [unnecessary pointer casts](#Pro-type-unnecessarycast).
+* Warn against [identity casts](#Pro-type-identitycast) between pointer types, where the source and target types are the same (#Pro-type-identitycast)
+* Warn if a pointer cast could be [implicit](#Pro-type-implicitpointercast)
 
 ### <a name="Res-casts-named"></a>ES.49: If you must use a cast, use a named cast
 
@@ -19401,8 +19402,9 @@ Type safety profile summary:
 
 * <a name="Pro-type-avoidcasts"></a>Type.1: [Avoid casts](#Res-casts):  
 <a name="Pro-type-reinterpretcast">a. </a>Don't use `reinterpret_cast`; A strict version of [Avoid casts](#Res-casts) and [prefer named casts](#Res-casts-named).  
-<a name="Pro-type-arithmeticcast">b. </a>Don't a `static_cast` for arithmetic types; A strict version of [Avoid casts](#Res-casts) and [prefer named casts](#Res-casts-named).  
-<a name="Pro-type-unnecessarycast">c. </a>Don't use pointer unnecessary pointer casts; A strict version of [Avoid casts](#Res-casts)  
+<a name="Pro-type-arithmeticcast">b. </a>Don't use `static_cast` for arithmetic types; A strict version of [Avoid casts](#Res-casts) and [prefer named casts](#Res-casts-named).  
+<a name="Pro-type-identitycast">c. </a>Don't cast between pointer types where the source type and the target type are the same; A strict version of [Avoid casts](#Res-casts).
+<a name="Pro-type-implicitpointercast">d. </a>Don't cast between pointer types when the conversion could be implicit; A strict version of [Avoid casts](#Res-casts).
 * <a name="Pro-type-downcast"></a>Type.2: Don't use `static_cast` to downcast:
 [Use `dynamic_cast` instead](#Rh-dynamic_cast).
 * <a name="Pro-type-constcast"></a>Type.3: Don't use `const_cast` to cast away `const` (i.e., at all):

--- a/scripts/hunspell/isocpp.dic
+++ b/scripts/hunspell/isocpp.dic
@@ -214,6 +214,7 @@ HTTP
 Hyslop
 i2
 IDE
+identitycast
 IDEs
 IEC
 ifdef
@@ -221,6 +222,7 @@ iff
 ifstream
 impactful
 Impl
+implicitpointercast
 incompleat
 increment1
 Incrementable
@@ -551,7 +553,6 @@ uniqueptrparam
 unittest
 unittests
 unnamed2
-unnecessarycast
 use1
 users'
 UTF

--- a/scripts/hunspell/isocpp.dic
+++ b/scripts/hunspell/isocpp.dic
@@ -42,6 +42,7 @@ archetypical
 arg
 argh
 args
+arithmeticcast
 arr2
 arrayindex
 ASIC
@@ -550,6 +551,7 @@ uniqueptrparam
 unittest
 unittests
 unnamed2
+unnecessarycast
 use1
 users'
 UTF

--- a/scripts/hunspell/isocpp.dic
+++ b/scripts/hunspell/isocpp.dic
@@ -1,4 +1,5 @@
 '
+10'000
 0xFF0000
 0b0101'0101
 10x
@@ -78,6 +79,7 @@ class'
 clib
 Cline99
 ClosePort
+cm3
 CommonMark
 composability
 composable
@@ -126,6 +128,7 @@ default0
 default00
 defop
 del
+deref
 derived1
 derived2
 destructors
@@ -144,6 +147,7 @@ endl
 enum
 Enum
 enums
+EoP
 eq
 eqdefault
 EqualityComparable
@@ -183,6 +187,7 @@ g1
 g2
 GCC
 Geosoft
+getline
 getx
 GFM
 Girou
@@ -204,7 +209,9 @@ hnd
 homebrew
 HPL
 href
+HTTP
 Hyslop
+i2
 IDE
 IDEs
 IEC
@@ -262,6 +269,7 @@ lvalue
 lvalues
 m1
 m2
+m3
 macros2
 malloc
 mallocfree
@@ -300,6 +308,7 @@ mtx
 Murray93
 mutex
 mutexes
+mx
 myMap
 MyMap
 myset
@@ -327,6 +336,7 @@ nonvirtual
 nonvirtually
 nothrow
 NR
+nullness
 nullptr
 NVI
 ok
@@ -478,6 +488,7 @@ stmt
 str
 strdup
 strlen
+Str15
 Stroustrup
 Stroustrup00
 Stroustrup05
@@ -513,6 +524,7 @@ thread2
 Tjark
 tmp
 TMP
+tock
 TODO
 toolchains
 TotallyOrdered
@@ -525,6 +537,8 @@ typeid
 typename
 typesafe
 UB
+u1
+u2
 unaliased
 uncompromised
 underuse


### PR DESCRIPTION
[Issue #926 for discussion](https://github.com/isocpp/CppCoreGuidelines/issues/926)

- Warn on unnecessary casts
- Avoid casts on arithmetic types
- Add specializations of the rules for Pro-type-reinterpretcast