### PR TITLE
Fix Markdown rendering failure

### DIFF
--- a/CppCoreGuidelines.md
+++ b/CppCoreGuidelines.md
@@ -18089,7 +18089,7 @@ Avoid accidentally becoming dependent on implementation details and logically se
         }
     }
 
-<iostream> exposes the definition of `std::string` ("why?" makes for a fun trivia question),
+`<iostream>` exposes the definition of `std::string` ("why?" makes for a fun trivia question),
 but it is not required to do so by transitively including the entire `<string>` header,
 resulting in the popular beginner question "why doesn't `getline(cin,s);` work?"
 or even an occasional "`string`s cannot be compared with `==`).


### PR DESCRIPTION
Use of `<iostream>` without backticks causes the Markdown render to fail from this point onwards on GitHub pages. See [SF.10 on the pretty gh-pages version](https://isocpp.github.io/CppCoreGuidelines/CppCoreGuidelines#Rs-implicit) - everything below it is interpreted as raw text due to `<iostream>` being interpreted as an HTML tag.