### PR TITLE
New rule: I.27 Pimpl

### DIFF
--- a/scripts/hunspell/isocpp.dic
+++ b/scripts/hunspell/isocpp.dic
@@ -101,6 +101,7 @@ CplusplusCS
 cpp
 cpp98
 CppCon
+cppreference
 CRTP
 cst
 cstdarg
@@ -193,6 +194,7 @@ GFM
 Girou
 github
 GitHub
+GOTW
 gp
 GPLv3
 gsl
@@ -219,6 +221,7 @@ ifdef
 iff
 ifstream
 impactful
+impl
 Impl
 incompleat
 increment1
@@ -366,7 +369,8 @@ pb2
 pc
 performant
 pessimization
-PIMPL
+pimpl
+Pimpl
 Pirkelbauer
 PL4
 PLDI


### PR DESCRIPTION
There are three dangling references to PIMPL in the guidelines. I believe it fits naturally as rule I.27 (right after another ABI rule). 

I also attempt to regularize the spelling as "Pimpl" (following gotw 100, wikipedia, c2, drdobbs), rather than "PIMPL" (current guidelines) or "pImpl" (cppreference), feel free to suggest changes.