### PR TITLE
fix mismatch between title and toc for F.22

### DIFF
--- a/CppCoreGuidelines.md
+++ b/CppCoreGuidelines.md
@@ -2236,7 +2236,7 @@ Parameter passing expression rules:
 
 Parameter passing semantic rules:
 
-* [F.22: Use `T*` or `owner<T*>` or a smart pointer to designate a single object](#Rf-ptr)
+* [F.22: Use `T*` or `owner<T*>` to designate a single object](#Rf-ptr)
 * [F.23: Use a `not_null<T>` to indicate "null" is not a valid value](#Rf-nullptr)
 * [F.24: Use a `span<T>` or a `span_p<T>` to designate a half-open sequence](#Rf-range)
 * [F.25: Use a `zstring` or a `not_null<zstring>` to designate a C-style string](#Rf-zstring)


### PR DESCRIPTION
F.22 appears in the table of contents as

    F.22: Use T* or owner<T*> or a smart pointer to designate a single object

and in the main body of text as

    F.22: Use T* or owner<T*> to designate a single object
 
This was that way since the initial commit in 9/2015, https://github.com/isocpp/CppCoreGuidelines/blob/947cf3affcdfc392a316a32f73cdea7383ae55bd/CppCoreGuidelines.md (it was called F.16 back then)

This PR proposes to use the main body version for both, this is a rule that explains what raw pointers are for and smart pointers are not mentioned in text.