### PR TITLE
Fix typos and change spellcheck call to not check URLs

### DIFF
--- a/CppCoreGuidelines.md
+++ b/CppCoreGuidelines.md
@@ -8453,7 +8453,7 @@ The use of a `static_cast` is not pretty, but
         return d = (d== Day::sun) ? Day::mon : Day{++d};    // error
     }
     
-is an infinite recursion, and writing it without a cast, using a `switch` on all cases is longwinded.
+is an infinite recursion, and writing it without a cast, using a `switch` on all cases is long-winded.
 
 
 ##### Enforcement
@@ -19505,10 +19505,10 @@ A textbook for beginners and relative novices.
 * Bjarne Stroustrup: [The Essence of C++: With Examples in C++84, C++98, C++11, and C++14](http://channel9.msdn.com/Events/GoingNative/2013/Opening-Keynote-Bjarne-Stroustrup). 2013
 * All the talks from [CppCon '14](https://isocpp.org/blog/2014/11/cppcon-videos-c9)
 * Bjarne Stroustrup: [The essence of C++](https://www.youtube.com/watch?v=86xWVb4XIyE) at the University of Edinburgh. 2014.
-* Bjarne Stroustrup: [The Evolution of C++ Past, Present and Future](https://www.youtube.com/watch?v=_wzc7a3McOs). Cppcon 2016 keynote.
-* Bjarne Stroustrup: [Make Simple Tasks Simple!](https://www.youtube.com/watch?v=nesCaocNjtQ). Cppcon 2014 keynote.
-* Bjarne Stroustrup: [Writing Good C++14](https://www.youtube.com/watch?v=1OEu9C51K2A). Cppcon 2015 keynote about the Core Guidelines.
-* Herb Sutter: [Writing Good C++14... By Default](https://www.youtube.com/watch?v=hEx5DNLWGgA). Cppcon 2015 keynote about the Core Guidelines.
+* Bjarne Stroustrup: [The Evolution of C++ Past, Present and Future](https://www.youtube.com/watch?v=_wzc7a3McOs). CppCon 2016 keynote.
+* Bjarne Stroustrup: [Make Simple Tasks Simple!](https://www.youtube.com/watch?v=nesCaocNjtQ). CppCon 2014 keynote.
+* Bjarne Stroustrup: [Writing Good C++14](https://www.youtube.com/watch?v=1OEu9C51K2A). CppCon 2015 keynote about the Core Guidelines.
+* Herb Sutter: [Writing Good C++14... By Default](https://www.youtube.com/watch?v=hEx5DNLWGgA). CppCon 2015 keynote about the Core Guidelines.
 * CppCon 15
 * ??? C++ Next
 * ??? Meting C++
@@ -19529,17 +19529,17 @@ A textbook for beginners and relative novices.
 This section contains materials that has been useful for presenting the core guidelines and the ideas behind them:
 
 * [Our documents directory](https://github.com/isocpp/CppCoreGuidelines/tree/master/docs)
-* Stroustrup, Sutter, and Dos Reis: [A brief introduction to C++’s model for type- and resource-safety](http://www.stroustrup.com/resource-model.pdf). A paper with lots of examples.
-* Segey Subkov: [a Core Guidelines talk](https://www.youtube.com/watch?v=DyLwdl_6vmU)
+* Stroustrup, Sutter, and Dos Reis: [A brief introduction to C++'s model for type- and resource-safety](http://www.stroustrup.com/resource-model.pdf). A paper with lots of examples.
+* Sergey Zubkov: [a Core Guidelines talk](https://www.youtube.com/watch?v=DyLwdl_6vmU)
 and here are the [slides](http://2017.cppconf.ru/talks/sergey-zubkov). In Russian. 2017.
-* Neil MacIntosh: [The Guideline Support Library: One Year Later](https://www.youtube.com/watch?v=_GhNnCuaEjo). Cppcon 2016.
-* Bjarne Stroustrup: [Writing Good C++14](https://www.youtube.com/watch?v=1OEu9C51K2A). Cppcon 2015 keynote.
-* Herb Sutter: [Writing Good C++14... By Default](https://www.youtube.com/watch?v=hEx5DNLWGgA). Cppcon 2015 keynote.
+* Neil MacIntosh: [The Guideline Support Library: One Year Later](https://www.youtube.com/watch?v=_GhNnCuaEjo). CppCon 2016.
+* Bjarne Stroustrup: [Writing Good C++14](https://www.youtube.com/watch?v=1OEu9C51K2A). CppCon 2015 keynote.
+* Herb Sutter: [Writing Good C++14... By Default](https://www.youtube.com/watch?v=hEx5DNLWGgA). CppCon 2015 keynote.
 * Peter Sommerlad: [C++ Core Guidelines - Modernize your C++ Code Base](https://www.youtube.com/watch?v=fQ926v4ZzAM). ACCU 2017.
 * Bjarne Stroustrup: [No Littering!](https://www.youtube.com/watch?v=01zI9kV4h8c). Bay Area ACCU 2016.
-It gives some idea of the ambition level for the Core uidelines.
+It gives some idea of the ambition level for the Core Guidelines.
 
-Note that slides for Cppcon presentations are available (links with the posted videos videos).
+Note that slides for CppCon presentations are available (links with the posted videos videos).
 
 Contributions to this list would be most welcome.
 

--- a/scripts/Makefile
+++ b/scripts/Makefile
@@ -86,7 +86,7 @@ check-badchars: $(SOURCEPATH) $(BUILD_DIR) Makefile
 .PHONY: hunspell-check
 hunspell-check: $(BUILD_DIR)/plain-nohtml.txt
 	@echo '##################### Spell check ##################'
-	hunspell -d hunspell/en_US -p hunspell/isocpp.dic -u < build/plain-nohtml.txt > $(BUILD_DIR)/hunspell-report.txt
+	sed -e 's!http\(s\)\{0,1\}://[^[:space:]]*!!g' build/plain-nohtml.txt | hunspell -d hunspell/en_US -p hunspell/isocpp.dic -u  > $(BUILD_DIR)/hunspell-report.txt
 	@if [ -s $(BUILD_DIR)/hunspell-report.txt ]; then echo 'Warning: Spellcheck failed, fix words or add to dictionary:'; cat $(BUILD_DIR)/hunspell-report.txt; false; fi;
 
 # only list words that are not in dict
@@ -94,7 +94,7 @@ hunspell-check: $(BUILD_DIR)/plain-nohtml.txt
 # cat hunspell/isocpp.dic | sort | uniq > hunspell/isocpp.dic2; mv hunspell/isocpp.dic2 hunspell/isocpp.dic
 .PHONY: hunspell-list
 hunspell-list: $(BUILD_DIR)/plain.txt
-	hunspell -p hunspell/isocpp.dic -l < build/plain-nohtml.txt
+	sed -e 's!http\(s\)\{0,1\}://[^[:space:]]*!!g' build/plain-nohtml.txt | hunspell -p hunspell/isocpp.dic -l
 
 #### Cpplint
 

--- a/scripts/hunspell/isocpp.dic
+++ b/scripts/hunspell/isocpp.dic
@@ -26,6 +26,7 @@ ABIs
 abstr
 accessor
 ack
+ACCU
 addressof
 adl
 ADL
@@ -480,6 +481,7 @@ smartptrget
 smartptrparam
 smartptrs
 SMS
+Sommerlad
 SomeLargeType
 specialization2
 spinlock


### PR DESCRIPTION
I changed the shell line that invokes hunspell to make a small sed-effort to ignore URLs, since the last batch of changes introduced a lot of false positive detections.