### PR TITLE
update rendered page sidebar

### DIFF
--- a/_includes/head.html
+++ b/_includes/head.html
@@ -49,7 +49,7 @@
       spanTag.parentNode.replaceChild(node, spanTag);
     }
     $(function() {
-      $("button")
+      $("#hl_button")
         .click(function( event ) {
           $("pre code").toggleClass("cpp");
           $("pre code").toggleClass("hljs");

--- a/_includes/sidebar.html
+++ b/_includes/sidebar.html
@@ -13,8 +13,10 @@
     <nav class="sidebar-nav">
       <small>
         {% if page.name == "CppCoreGuidelines.md" %}
+
       <!-- Items have to be added manually until for now -->
-      <a class="sidebar-nav-item active" href="#main">Top</a>
+      <b><a class="sidebar-nav-item active" href="#main">Top</a></b>
+
       <a class="sidebar-nav-item active" href="#S-introduction">In: Introduction</a>
       <a class="sidebar-nav-item active" href="#S-philosophy">P: Philosophy</a>
       <a class="sidebar-nav-item active" href="#S-interfaces">I: Interfaces</a>
@@ -23,28 +25,29 @@
       <a class="sidebar-nav-item active" href="#S-enum">Enum: Enumerations</a>
       <a class="sidebar-nav-item active" href="#S-resource">R: Resource management</a>
       <a class="sidebar-nav-item active" href="#S-expr">ES: Expressions and statements</a>
+      <a class="sidebar-nav-item active" href="#S-performance">Per: Performance</a>
+      <a class="sidebar-nav-item active" href="#S-concurrency">CP: Concurrency</a>
       <a class="sidebar-nav-item active" href="#S-errors">E: Error handling</a>
       <a class="sidebar-nav-item active" href="#S-const">Con: Constants and immutability</a>
       <a class="sidebar-nav-item active" href="#S-templates">T: Templates and generic programming</a>
-      <a class="sidebar-nav-item active" href="#S-concurrency">CP: Concurrency</a>
-      <a class="sidebar-nav-item active" href="#S-stdlib">STL: The Standard library</a>
-      <a class="sidebar-nav-item active" href="#S-source">SF: Source files</a>
       <a class="sidebar-nav-item active" href="#S-cpl">CPL: C-style programming</a>
-      <a class="sidebar-nav-item active" href="#S-profile">PRO: Profiles</a>
-      <a class="sidebar-nav-item active" href="#S-gsl">GSL: Guideline support library</a>
-      <a class="sidebar-nav-item active" href="#S-faq">FAQ: Answers to frequently asked questions</a>
-
-      <a class="sidebar-nav-item active" href="#S-naming">NL: Naming and layout</a>
-      <a class="sidebar-nav-item active" href="#S-performance">PER: Performance</a>
+      <a class="sidebar-nav-item active" href="#S-source">SF: Source files</a>
+      <a class="sidebar-nav-item active" href="#S-stdlib">SL: The Standard library</a>
+      <br/>
+      <a class="sidebar-nav-item active" href="#S-A">A: Architectural Ideas</a>
       <a class="sidebar-nav-item active" href="#S-not">N: Non-Rules and myths</a>
       <a class="sidebar-nav-item active" href="#S-references">RF: References</a>
+      <a class="sidebar-nav-item active" href="#S-profile">Pro: Profiles</a>
+      <a class="sidebar-nav-item active" href="#S-gsl">GSL: Guideline support library</a>
+      <a class="sidebar-nav-item active" href="#S-naming">NL: Naming and layout</a>
+      <a class="sidebar-nav-item active" href="#S-faq">FAQ: Frequently asked questions</a>
       <a class="sidebar-nav-item active" href="#S-libraries">Appendix A: Libraries</a>
       <a class="sidebar-nav-item active" href="#S-modernizing">Appendix B: Modernizing code</a>
       <a class="sidebar-nav-item active" href="#S-discussion">Appendix C: Discussion</a>
+      <a class="sidebar-nav-item active" href="#S-tools">Appendix D: Tools support</a>
       <a class="sidebar-nav-item active" href="#S-glossary">Glossary</a>
       <a class="sidebar-nav-item active" href="#S-unclassified">To-do: Unclassified proto-rules</a>
       <button id="button">Highlighting</button>
-
         {% else %}
 
       <a class="sidebar-nav-item active" href="CppCoreGuidelines.html">C++ Core Guidelines</a>

--- a/_includes/sidebar.html
+++ b/_includes/sidebar.html
@@ -7,13 +7,15 @@
           C++ Core Guidelines
         </a>
       </h3>
-      <p class="lead">{{ site.description }}</p>
     </div>
-
     <nav class="sidebar-nav">
       <small>
         {% if page.name == "CppCoreGuidelines.md" %}
 
+        <div class="switch">
+          <input class="tgl tgl-cpp" id="hl_button" type="checkbox"/>
+          <label class="tgl-btn" data-tg-off="No highlight" data-tg-on="Highlight" for="hl_button"></label>
+        </div>
       <!-- Items have to be added manually until for now -->
       <b><a class="sidebar-nav-item active" href="#main">Top</a></b>
 
@@ -47,7 +49,6 @@
       <a class="sidebar-nav-item active" href="#S-tools">Appendix D: Tools support</a>
       <a class="sidebar-nav-item active" href="#S-glossary">Glossary</a>
       <a class="sidebar-nav-item active" href="#S-unclassified">To-do: Unclassified proto-rules</a>
-      <button id="button">Highlighting</button>
         {% else %}
 
       <a class="sidebar-nav-item active" href="CppCoreGuidelines.html">C++ Core Guidelines</a>

--- a/public/css/custom.css
+++ b/public/css/custom.css
@@ -129,3 +129,72 @@ p:after {
         color: #000;
     }
 }
+
+
+.tgl {
+  display: none;
+}
+.tgl + .tgl-btn {
+  outline: 0;
+  display: block;
+  width: 8em;
+  height: 2em;
+  position: relative;
+  cursor: pointer;
+  -webkit-user-select: none;
+     -moz-user-select: none;
+      -ms-user-select: none;
+          user-select: none;
+}
+.tgl + .tgl-btn:after, .tgl + .tgl-btn:before {
+  position: relative;
+  display: block;
+  content: "";
+  width: 50%;
+  height: 100%;
+}
+.tgl + .tgl-btn:after {
+  left: 0;
+}
+.tgl + .tgl-btn:before {
+  display: none;
+}
+.tgl:checked + .tgl-btn:after {
+  left: 50%;
+}
+
+.tgl-cpp + .tgl-btn {
+  overflow: hidden;
+  -webkit-backface-visibility: hidden;
+          backface-visibility: hidden;
+  background: #888;
+}
+.tgl-cpp + .tgl-btn:after, .tgl-cpp + .tgl-btn:before {
+  display: inline-block;
+  width: 100%;
+  text-align: center;
+  position: absolute;
+  line-height: 2em;
+  font-weight: bold;
+  color: #fff;
+}
+.tgl-cpp + .tgl-btn:after {
+  left: 100%;
+  content: attr(data-tg-on);
+}
+.tgl-cpp + .tgl-btn:before {
+  left: 0;
+  content: attr(data-tg-off);
+}
+.tgl-cpp + .tgl-btn:active {
+  background: #888;
+}
+.tgl-cpp:checked + .tgl-btn {
+  background: #268bd2;
+}
+.tgl-cpp:checked + .tgl-btn:before {
+  left: -100%;
+}
+.tgl-cpp:checked + .tgl-btn:after {
+  left: 0;
+}

--- a/public/css/hyde.css
+++ b/public/css/hyde.css
@@ -55,7 +55,7 @@ html {
 
 .sidebar {
   text-align: center;
-  padding: 2rem 1rem;
+  padding: none;
   color: rgba(255,255,255,.5);
   background-color: #202020;
 }
@@ -112,7 +112,7 @@ a.sidebar-nav-item:focus {
     right:  1rem;
     bottom: 1rem;
     left:   1rem;
-    top:    1rem;
+    top:    0rem;
   }
 }
 


### PR DESCRIPTION
The table of contents has changed (some time ago), and has to be manually updated in the sidebar for the pretty-rendered github page. Also I finally took some time to make the highlight button look prettier (arguably).

Before merging, while you may not wish to debate the css/html code, you can at least preview the results here:
http://tkruse.github.io/CppCoreGuidelines/CppCoreGuidelines.html

Open with various browsers to test compatibility.