### PR TITLE
Fix Inconsistent definition of czstring in comments

### DIFF
--- a/CppCoreGuidelines.md
+++ b/CppCoreGuidelines.md
@@ -18755,7 +18755,7 @@ Distinguishing these alternatives prevents misunderstandings and bugs.
 All we know is that it is supposed to be the nullptr or point to at least one character
 
     void f1(zstring s);     // s is a C-style string or the nullptr
-    void f1(czstring s);    // s is a C-style string that is not the nullptr
+    void f1(czstring s);    // s is a C-style string constant or the nullptr
     void f1(std::byte* s);  // s is a pointer to a byte (C++17)
 
 ##### Note


### PR DESCRIPTION
Comments in sections  SL.str.3 and GSL.view disagree on whether czstring may be the nullptr.

This PR fixes the first comment definition in SL.str.3 that czstring `is a C-style string that is not the nullptr`

### SL.str.3: Use zstring or czstring to refer to a C-style, zero-terminated, sequence of characters
```
void f1(zstring s);     // s is a C-style string or the nullptr
void f1(czstring s);    // s is a C-style string that is not the nullptr
```
### GSL.view: Views
`zstring` // a `char*` supposed to be a C-style string; that is, a zero-terminated sequence of `char` or `nullptr`
`czstring` // a `const char*` supposed to be a C-style string; that is, a zero-terminated sequence of const `char` or `nullptr`