### PR TITLE
Fix Fibonacci sequence

### DIFF
--- a/CppCoreGuidelines.md
+++ b/CppCoreGuidelines.md
@@ -10352,7 +10352,7 @@ The C++17 rules are somewhat less surprising:
 
 So use `={...}` if you really want an `initializer_list<T>`
 
-    auto fib10 = {0, 1, 2, 3, 5, 8, 13, 21, 34, 55};   // fib10 is a list
+    auto fib10 = {1, 1, 2, 3, 5, 8, 13, 21, 34, 55};   // fib10 is a list
 
 ##### Note
 


### PR DESCRIPTION
A number sequence called `fib` should be the Fibonacci sequence or have a different name.

https://en.wikipedia.org/wiki/Fibonacci_number