### PR TITLE
Fix typo in C.8

### DIFF
--- a/CppCoreGuidelines.md
+++ b/CppCoreGuidelines.md
@@ -4169,7 +4169,7 @@ Prefer to place the interface first in a class [see](#Rl-order).
 
 ##### Enforcement
 
-Flag classes declared with `struct` if there is a `private` or `public` member.
+Flag classes declared with `struct` if there is a `private` or `protected` member.
 
 ### <a name="Rc-private"></a>C.9: Minimize exposure of members
 


### PR DESCRIPTION
> C.8: Use `class` rather than `struct` if any member is non-public
> ...
> Enforcement: Flag classes declared with `struct` if there is a `private` or `public` member.

The enforcement line should read "`private` or `protected`".