### PR TITLE
Fixing typo / improving language in NR.3

### DIFF
--- a/CppCoreGuidelines.md
+++ b/CppCoreGuidelines.md
@@ -19322,7 +19322,7 @@ Many, possibly most, problems with exceptions stem from historical needs to inte
 
 The fundamental arguments for the use of exceptions are
 
-* They clearly separates error return from ordinary return
+* They clearly differentiate between erroneous return and ordinary return
 * They cannot be forgotten or ignored
 * They can be used systematically
 


### PR DESCRIPTION
Current text has a plurality typo ("separates" vs "separate"), modified version more precisely conveys the idea.