### PR TITLE
Fixing memory handling in E.5 example

### DIFF
--- a/CppCoreGuidelines.md
+++ b/CppCoreGuidelines.md
@@ -14704,8 +14704,8 @@ Not all member functions can be called.
         // if elem != nullptr then elem points to sz doubles
     public:
         Vector() : elem{nullptr}, sz{0}{}
-        Vector(int s) : elem{new double}, sz{s} { /* initialize elements */ }
-        ~Vector() { delete elem; }
+        Vector(int s) : elem{new double[s]}, sz{s} { /* initialize elements */ }
+        ~Vector() { delete [] elem; }
         double& operator[](int s) { return elem[s]; }
         // ...
     private:


### PR DESCRIPTION
Instead of constructing an array, it constructs and deletes a single double, and accesses elements as if it had constructed an array.