### PR TITLE
C.129: fix typo in example 

### DIFF
--- a/CppCoreGuidelines.md
+++ b/CppCoreGuidelines.md
@@ -6885,7 +6885,7 @@ And we could extend the hierarchies by adding a Smiley class (:-)):
         // ...
     };
 
-    class Impl::Smiley : Public Smiley, public Impl::Circle {   // implementation
+    class Impl::Smiley : public Smiley, public Impl::Circle {   // implementation
     public:
         // constructors, destructor
         // ...


### PR DESCRIPTION
 `Public` -> `public`