### PR TITLE
as pointed out at CppCon, 'inkorrekt and incompleat' doesn't translate

### DIFF
--- a/CppCoreGuidelines.md
+++ b/CppCoreGuidelines.md
@@ -8,7 +8,7 @@ Editors:
 * [Bjarne Stroustrup](http://www.stroustrup.com)
 * [Herb Sutter](http://herbsutter.com/)
 
-This document is a very early draft. It is inkorrekt, incompleat, and pÂµÃoorly formatted.
+This document is an early draft.
 Had it been an open-source (code) project, this would have been release 0.8.
 Copying, use, modification, and creation of derivative works from this project is licensed under an MIT-style license.
 Contributing to this project requires agreeing to a Contributor License. See the accompanying [LICENSE](LICENSE) file for details.


### PR DESCRIPTION
In the Bjarne's keynote Q&A session, it was pointed out that "inkorrekt and incompleat" at the start of Core Guidelines was a blocker for adoption somewhere because the joke did not translate well.