### PR TITLE
Break long lines to increase readability in files

### DIFF
--- a/scripts/python/cpplint_wrap.py
+++ b/scripts/python/cpplint_wrap.py
@@ -3,7 +3,13 @@ import cpplint
 import sys
 
 def main():
-    FILTERS='cpplint --verbose=0 --linelength=100 --filter=-legal/copyright,-build/include_order,-build/c++11,-build/namespaces,-build/class,-build/include,-build/include_subdir,-readability/inheritance,-readability/function,-readability/casting,-readability/namespace,-readability/alt_tokens,-readability/braces,-readability/fn_size,-whitespace/comments,-whitespace/braces,-whitespace/empty_loop_body,-whitespace/indent,-whitespace/newline,-runtime/explicit,-runtime/arrays,-runtime/int,-runtime/references,-runtime/string,-runtime/operator,-runtime/printf'.split(' ')
+    FILTERS='cpplint --verbose=0 --linelength=100 --filter=-legal/copyright,-build/include_order,'
+            'build/c++11,-build/namespaces,-build/class,-build/include,-build/include_subdir,'
+            'readability/inheritance,-readability/function,-readability/casting,'
+            'readability/namespace,-readability/alt_tokens,-readability/braces,-readability/fn_size,'
+            'whitespace/comments,-whitespace/braces,-whitespace/empty_loop_body,-whitespace/indent,'
+            'whitespace/newline,-runtime/explicit,-runtime/arrays,-runtime/int,-runtime/references,'
+            'runtime/string,-runtime/operator,-runtime/printf'.split(' ')
 
     result = False
     files = sys.argv[1:]

--- a/scripts/python/md-split.py
+++ b/scripts/python/md-split.py
@@ -18,15 +18,19 @@ def main():
     """
     This script ended up ugly, so in case somebody wants to reimplement, here is the spec that grew by time.
 
-    What it should do it take a markdown file, and split it into more files. A targetfile should have the same number of lines as the original, with source code snippets and markdown non-words removed, for spell-checking.
+    What it should do it take a markdown file, and split it into more files. A targetfile should have the same
+    number of lines as the original, with source code snippets and markdown non-words removed, for spell-checking.
 
     Each code snipped should go into a separate file in codedir.
 
-    Each code snipped should get additional C++ code around it to help compile the line in context, with some heuristic guessing of what is needed around. The wrapping code should have a token in each line allowing other tools to filter out these lines
+    Each code snipped should get additional C++ code around it to help compile the line in context, with some
+    heuristic guessing of what is needed around. The wrapping code should have a token in each line allowing other
+    tools to filter out these lines.
 
     The name for each file chosen consists os the section id in the markdown document, a counter for the snippet inside the section.
 
-    Snippets without code (only comments) or containing lines starting with ??? should not yeld files, but the counter for naming snippets should still increment.
+    Snippets without code (only comments) or containing lines starting with ??? should not yeld files,
+    but the counter for naming snippets should still increment.
     """
     parser = argparse.ArgumentParser(description='Split md file into plain text and code blocks')
     parser.add_argument('sourcefile',


### PR DESCRIPTION
There were some very long lines in Python script files (comments and
cpplint execution command), really painful to read, so I decided to
break them into several lines in order to increase readability.