### PR TITLE
struct -> class to conform to C8

### DIFF
--- a/CppCoreGuidelines.md
+++ b/CppCoreGuidelines.md
@@ -4198,7 +4198,7 @@ This may be exactly what we want, but if we want to enforce a relation among mem
 and enforce that relation (invariant) through constructors and member functions.
 For example:
 
-    struct Distance {
+    class Distance {
     public:
         // ...
         double meters() const { return magnitude*unit; }


### PR DESCRIPTION
In "C.9: Minimize exposure of members", we are given an example of `struct pair` to illustrate that since `a` and `b` are public, no matter what interface functions etc. are introduced, we will not be able to enforce an invariant on them. As a 'good' example, we are shown `struct Distance`, which has public interface functions and private data. However, in the directly preceding section, we are advised to "C.8: Use class rather than struct if any member is non-public". Therefore, `struct Distance` sends a mixed message to the reader, and should be amended to `class Distance`.