### PR TITLE
Add virtual destructor to base class "Device"

### DIFF
--- a/CppCoreGuidelines.md
+++ b/CppCoreGuidelines.md
@@ -6530,6 +6530,7 @@ Such as on an ABI (link) boundary.
 ##### Example
 
     struct Device {
+        virtual ~Device() = default;
         virtual void write(span<const char> outbuf) = 0;
         virtual void read(span<char> inbuf) = 0;
     };


### PR DESCRIPTION
Add virtual destructor to interface class following recommendation of [C.127](https://github.com/isocpp/CppCoreGuidelines/blob/master/CppCoreGuidelines.md#c127-a-class-with-a-virtual-function-should-have-a-virtual-or-protected-destructor).