### PR TITLE
Break comment to respect 100 column limit

### DIFF
--- a/CppCoreGuidelines.md
+++ b/CppCoreGuidelines.md
@@ -13399,7 +13399,8 @@ Application concepts are easier to reason about.
 
     void some_fun() {
         std::string  msg, msg2;
-        std::thread publisher([&] { msg = "Hello"; });       // bad (less expressive and more error-prone)
+        std::thread publisher([&] { msg = "Hello"; });       // bad: less expressive
+                                                             //      and more error-prone
         auto pubtask = std::async([&] { msg2 = "Hello"; });  // OK
         // ...
         publisher.join();


### PR DESCRIPTION
Broken line into two to respect the 100 character limit. Also using "bad: " instead of "bad (" since it appears to be more common over the document