### PR TITLE
Avoid magic constant in F.44

### DIFF
--- a/CppCoreGuidelines.md
+++ b/CppCoreGuidelines.md
@@ -3565,7 +3565,7 @@ The language guarantees that a `T&` refers to an object, so that testing for `nu
         array<wheel, 4> w;
         // ...
     public:
-        wheel& get_wheel(size_t i) { Expects(i < 4); return w[i]; }
+        wheel& get_wheel(size_t i) { Expects(i < w.size()); return w[i]; }
         // ...
     };
 


### PR DESCRIPTION
In the example, the literal `4` was duplicated as the `array` size and in the `Expects` precondition (violates ES.45). Fixed that, so the `Expects` uses `array`'s `size()` instead.