### PR TITLE
fixed spellcheck/lint issues on running make in ./scripts/

### DIFF
--- a/CppCoreGuidelines.md
+++ b/CppCoreGuidelines.md
@@ -20207,7 +20207,7 @@ Minimize unintentional conversions.
 ##### Example, good
 
     void print(int i);
-    void print(string_view);    // also works on any stringlike sequence
+    void print(string_view);    // also works on any string-like sequence
 
     print(1);              // clear, automatic type matching
     print("xyzzy");        // clear, automatic type matching
@@ -20231,7 +20231,7 @@ Some styles use very general (not type-specific) prefixes to denote the general 
     // note: "p" is not being used to say "raw pointer to type User,"
     //       just generally to say "this is an indirection"
 
-    auto cntHits = calc_total_of_hits(/*...*);
+    auto cntHits = calc_total_of_hits(/*...*/);
     // note: "cnt" is not being used to encode a type,
     //       just generally to say "this is a count of something"
 

--- a/scripts/hunspell/en_US.dic
+++ b/scripts/hunspell/en_US.dic
@@ -24073,6 +24073,7 @@ clutter/GSD
 cluttered/U
 cm
 cnidarian/MS
+cnt
 co/DES
 coach/MSRDG
 coacher/M


### PR DESCRIPTION
Fixed issues with hunspell and linter when running `make` in scripts sub folder as listed below:

```
[...]
##################### Spell check ##################
sed -e 's!http\(s\)\{0,1\}://[^[:space:]]*!!g' build/plain-nohtml.txt | hunspell -d hunspell/en_US -p hunspell/isocpp.dic -u  > build/hunspell-report.txt
Warning: Spellcheck failed, fix words or add to dictionary:
Line 20210: stringlike -> springlike
Line 20235: cnt -> ctn
make: *** [hunspell-check] Error 1
[...]
````
```
[...]
Rl-name-type3.cpp:20:  Complex multi-line /*...*/-style comment found. Lint may give bogus warnings.  Consider replacing these with //-style comments, with #if 0...#endif, or with more clearly structured multi-line comments.  [readability/multiline_comment] [5]
Done processing Rl-name-type3.cpp
Total errors found: 1
 14  // ../CppCoreGuidelines.md : 20229
 15  auto p = new User();
 16  auto p = make_unique<User>();
 17  // note: "p" is not being used to say "raw pointer to type User,"
 18  //       just generally to say "this is an indirection"
 19  
 20  auto cntHits = calc_total_of_hits(/*...*);
 21  // note: "cnt" is not being used to encode a type,
 22  //       just generally to say "this is a count of something"
Done processing Rl-name-type4.cpp
[...]
Done processing S-unclassified0.cpp
make[1]: *** [cpplint-all] Error 1
make[1]: Leaving directory `...`
make: *** [cpplint-all] Error 2
```