### PR TITLE
Should say repository instead of depository

### DIFF
--- a/CppCoreGuidelines.md
+++ b/CppCoreGuidelines.md
@@ -1143,7 +1143,7 @@ See
 * [Concurrency tools](#Rconc-tools)
 * [Testing tools](???)
 
-There are many other kinds of tools, such as source code depositories, build tools, etc.,
+There are many other kinds of tools, such as source code repositories, build tools, etc.,
 but those are beyond the scope of these guidelines.
 
 ##### Note


### PR DESCRIPTION
Right? Depository is a word, but "source code depository" returns 34,400 Google hits (unrelated) while "source code repositories" returns 14,500,000.