### PR TITLE
Bug fix C4 class Foobar 

### DIFF
--- a/CppCoreGuidelines.md
+++ b/CppCoreGuidelines.md
@@ -4081,8 +4081,9 @@ The language requires operators `=`, `()`, `[]`, and `->` to be members.
 An overload set may have some members that do not directly access `private` data:
 
     class Foobar {
+    public:
         void foo(int x)    { /* manipulate private data */ }
-        void foo(double x) { foo(std::round(x)); }
+        void foo(double x) { foo(static_cast<int>(std::round(x))); }
         // ...
     private:
         // ...

--- a/CppCoreGuidelines.md
+++ b/CppCoreGuidelines.md
@@ -4082,8 +4082,8 @@ An overload set may have some members that do not directly access `private` data
 
     class Foobar {
     public:
-        void foo(int x)    { /* manipulate private data */ }
-        void foo(double x) { foo(narrow_cast<int>(std::round(x))); }
+        void foo(long x)    { /* manipulate private data */ }
+        void foo(double x) { foo(std::lround(x)); }
         // ...
     private:
         // ...

--- a/CppCoreGuidelines.md
+++ b/CppCoreGuidelines.md
@@ -4083,7 +4083,7 @@ An overload set may have some members that do not directly access `private` data
     class Foobar {
     public:
         void foo(int x)    { /* manipulate private data */ }
-        void foo(double x) { foo(static_cast<int>(std::round(x))); }
+        void foo(double x) { foo(narrow_cast<int>(std::round(x))); }
         // ...
     private:
         // ...


### PR DESCRIPTION
In C4 class Foobar under Exceptions, the function void Foobar::foo(double x) is supposed to call the overloaded void Foobar::foo(int x), but in the call foo(std::round(x)), std::round returns a double. Hence, it will get stuck in an infinite recursive loop. Added static_cast<int>(..) to enforce the call to right overload. Added also keyword public to be more consistent.