### PR TITLE
Copy-Paste-Typo in Comment for ES.87 sample (==0/!=0)

### DIFF
--- a/CppCoreGuidelines.md
+++ b/CppCoreGuidelines.md
@@ -12508,7 +12508,7 @@ The opposite condition is most easily expressed using a negation:
 
     // These all mean "if `p` is `nullptr`"
     if (!p) { ... }           // good
-    if (p == 0) { ... }       // redundant `!= 0`; bad: don't use `0` for pointers
+    if (p == 0) { ... }       // redundant `== 0`; bad: don't use `0` for pointers
     if (p == nullptr) { ... } // redundant `== nullptr`, not recommended
 
 ##### Enforcement


### PR DESCRIPTION
One of the samples for ES.87 says:
if (p == 0) { ... }       // redundant `!= 0`; bad: don't use `0` for pointers

It looks like this line was copied from a sample some lines above and "p!=0" in the code was changed to "p==0", but the comment was left unchanged.
This PR makes the comment consistent with the sample code.