### PR TITLE
Consistent usage of Stroustrup's naming style

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -88,7 +88,7 @@ Please use [Stroustrup](http://www.stroustrup.com/Programming/PPP-style.pdf) sty
 
     class Foo_bar
     {
-        void do_something(int arg_0);
+        void do_something(int arg);
     };
 
 #### Document style decisions

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -80,6 +80,17 @@ Please use 4-space indentation to trigger code parsing, rather than [fenced code
             std::cout << "This is code.\n";
         }
 
+#### Coding style
+
+Please use [Stroustrup](http://www.stroustrup.com/Programming/PPP-style.pdf) style for naming, like so:
+
+    This is some document text, with an example below:
+
+    class Foo_bar
+    {
+        void do_something(int arg_0);
+    };
+
 #### Document style decisions
 
 We've discussed and made decisions on a number of document style. Please do not open PRs that revisit these stylistic points:

--- a/CppCoreGuidelines.md
+++ b/CppCoreGuidelines.md
@@ -20270,11 +20270,11 @@ Like C++, some styles distinguishes types from non-types.
 For example, by capitalizing type names, but not the names of functions and variables.
 
     typename<typename T>
-    class HashTable {   // maps string to T
+    class Hash_table {   // maps string to T
         // ...
     };
 
-    HashTable<int> index;
+    Hash_table<int> index;
 
 This is not harmful and does not fall under this guideline because it does not encode type information.
 


### PR DESCRIPTION
I fix the inconsistency in naming convention https://github.com/isocpp/CppCoreGuidelines/issues/1148.
Also, as suggested by @blakehawkins, I edited `CONTRIBUTING.md`.