### PR TITLE
E.14 and E.18 samples do not catch by reference

### DIFF
--- a/CppCoreGuidelines.md
+++ b/CppCoreGuidelines.md
@@ -15137,7 +15137,7 @@ A user-defined type is unlikely to clash with other people's exceptions.
             my_code();
             // ...
         }
-        catch(Bufferpool_exhausted) {
+        catch(const Bufferpool_exhausted&) {
             // ...
         }
     }
@@ -15183,7 +15183,7 @@ The standard-library classes derived from `exception` should be used only as bas
             my_code();
             // ...
         }
-        catch(runtime_error) {   // runtime_error means "input buffer too small"
+        catch(const runtime_error&) {   // runtime_error means "input buffer too small"
             // ...
         }
     }


### PR DESCRIPTION
`E.15` states that exceptions should be catched from a hierarchy by (const) reference, but the samples provided in `E.14` and `E.18` catches the exceptions by value.

It s not the focus of those sample to explain whats the best practice on how to catch exceptions, but the first thing I thought when reading those was "what if we have a subclass?"

Even if this is probably not the first thought of every reader, being consistent on how to catch exception in the samples with the Core Guidelines should not harm, especially because it is a little difference.