### PR TITLE
Fixed get_string example in F.21

### DIFF
--- a/CppCoreGuidelines.md
+++ b/CppCoreGuidelines.md
@@ -3105,7 +3105,7 @@ To compare, if we passed out all values as return values, we would something lik
     pair<istream&, string> get_string(istream& is);  // not recommended
     {
         string s;
-        cin >> s;
+        is >> s;
         return {is, s};
     }
 


### PR DESCRIPTION
In the 'all values as return value' example in F.21, the passed istream was not used in the function.