### PR TITLE
P.5 example read int array size mismatch

### DIFF
--- a/CppCoreGuidelines.md
+++ b/CppCoreGuidelines.md
@@ -697,7 +697,7 @@ Or better still just use the type system and replace `Int` with `int32_t`.
     void read(int* p, int n);   // read max n integers into *p
 
     int a[100];
-    read(a, 100);    // bad
+    read(a, 1000);    // bad, off the end
 
 better
 

--- a/CppCoreGuidelines.md
+++ b/CppCoreGuidelines.md
@@ -697,7 +697,7 @@ Or better still just use the type system and replace `Int` with `int32_t`.
     void read(int* p, int n);   // read max n integers into *p
 
     int a[100];
-    read(a, 1000);    // bad
+    read(a, 100);    // bad
 
 better
 


### PR DESCRIPTION
It appears as though the max read int size is larger than the int array size itself.  Was this the intention in showing that there are possible bugs associated with such non-compile-time code?  If so, I think it would be clearer to put an exact equivalent approach.