### PR TITLE
[probable typo] Replace erroneous public keyword by private in C.129.

### DIFF
--- a/CppCoreGuidelines.md
+++ b/CppCoreGuidelines.md
@@ -6717,7 +6717,7 @@ The importance of keeping the two kinds of inheritance increases
         virtual void redraw();
 
         // ...
-    public:
+    private:
         Point cent;
         Color col;
     };


### PR DESCRIPTION
Hi everyone,

I think this example, although it is a bad example is not about public data, so the data members were probably meant to be private.

Thanks!

Stephan