### PR TITLE
clearer good example for P.5

### DIFF
--- a/CppCoreGuidelines.md
+++ b/CppCoreGuidelines.md
@@ -688,7 +688,7 @@ You don't need to write error handlers for errors caught at compile time.
 This example fails to achieve what it is trying to achieve (because overflow is undefined) and should be replaced with a simple `static_assert`:
 
     // Int is an alias used for integers
-    static_assert(sizeof(Int) >= 4);    // do: compile-time check
+    static_assert(sizeof(Int) * CHAR_BIT >= 32);    // do: compile-time check
 
 Or better still just use the type system and replace `Int` with `int32_t`.
 


### PR DESCRIPTION
The bad example in P.5 checks if Int is at least 32 bits long.
The good example checks if Int is at least 4 bytes long.
C++ intro.memory.1 says that a byte is wide enough for eight bit code of UTF-8, so checking for 4 bytes is OK. But the foot note for intro.memory.1 says that "The number of bits in a byte is reported by the macro CHAR_BIT in the header <climits>.".

I suggest the change in my PR because:
1. It better aligns the bad and the good example. In both cases the number of bits is directly checked against 32.
2. It would work on platforms with 11 bits per byte (other than the current version).
3. It makes readers think about the wrong but often made assumption that a byte is always 8 bits wide.