### PR TITLE
Formatting in C.46

### DIFF
--- a/CppCoreGuidelines.md
+++ b/CppCoreGuidelines.md
@@ -5379,7 +5379,7 @@ If you really want an implicit conversion from the constructor argument type to 
 
 ##### Note
 
-Copy and move constructors should not be made explicit because they do not perform conversions. Explicit copy/move constructors make passing and returning by value difficult.
+Copy and move constructors should not be made `explicit` because they do not perform conversions. Explicit copy/move constructors make passing and returning by value difficult.
 
 ##### Enforcement
 


### PR DESCRIPTION
In PR #1169 I added a short note. Now I realize that the word "explicit" in the note should better be formatted as code, as it is done in the rest of the document. This small commit changes that.
I am not sure if the "Explicit" at the start of the next sentence should also be formatted as code and how to write it (upper case E, lower case E?). So I only changed the first "explicit" in the note.