### PR TITLE
Fixed link for "avoid conversion operators"

### DIFF
--- a/CppCoreGuidelines.md
+++ b/CppCoreGuidelines.md
@@ -144,7 +144,7 @@ You can sample rules for specific language features:
 [when to use](#SS-lambdas)
 * operator:
 [conventional](#Ro-conventional) --
-[avoid conversion operators](#Ro-conventional) --
+[avoid conversion operators](#Ro-conversion) --
 [and lambdas](#Ro-lambda)
 * `public`, `private`, and `protected`:
 [information hiding](#Rc-private) --


### PR DESCRIPTION
At the top of the document there are links sorted by language features. For operators there is a link to "conventional" and one to "avoid conversion operators". Both links pointed to "conventional" (copy paste error?). This commit fixes the link to "avoid conversion operators".