### PR TITLE
Fix T.12's incorrect usage of vector::begin()

### DIFF
--- a/CppCoreGuidelines.md
+++ b/CppCoreGuidelines.md
@@ -16410,7 +16410,7 @@ Hard.
 
     vector<string> v;
     auto& x = v.front();     // bad
-    String& s = v.begin();   // good (String is a GSL concept)
+    String& s = v.front();   // good (String is a GSL concept)
 
 ##### Enforcement
 


### PR DESCRIPTION
Still not really sure about taking .front() from a 0 element vector but sure whatever