### PR TITLE
Pass parameter as reference in CP.31 example

### DIFF
--- a/CppCoreGuidelines.md
+++ b/CppCoreGuidelines.md
@@ -14130,12 +14130,12 @@ Defining "small amount" precisely is impossible.
 ##### Example
 
     string modify1(string);
-    void modify2(shared_ptr<string>);
+    void modify2(string&);
 
     void fct(string& s)
     {
         auto res = async(modify1, s);
-        async(modify2, &s);
+        async(modify2, s);
     }
 
 The call of `modify1` involves copying two `string` values; the call of `modify2` does not.


### PR DESCRIPTION
Fixes #1207.