### PR TITLE
fix padding of rendered codeblocks on github pages

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,9 @@
+scripts/build
+scripts/nodesjs/build
+node_modules
+_site
+scripts/python/__pycache__
+scripts/python/*.pyc
+
+# VS Code
+.vs/

--- a/CppCoreGuidelines.md
+++ b/CppCoreGuidelines.md
@@ -1,6 +1,3 @@
----
-layout: default
----
 # <a name="main"></a>C++ Core Guidelines
 
 April 16, 2018

--- a/INSTRUCTIONS.txt
+++ b/INSTRUCTIONS.txt
@@ -4,20 +4,15 @@ How to update the gh-pages at http://isocpp.github.io/CppCoreGuidelines/
 2. Update date in CppCoreGuidelines.md (and commit & push if updated)
 3. git checkout gh-pages
 4. git checkout master -- CppCoreGuidelines.md
-5. Add the following three lines to the top of CppCoreGuidelines.md:
 
----
-layout: default
----
-
-6. Replace all instances of {{ with {{ "{{" }}
+5. Replace all instances of {{ with {{ "{{" }}
    This escapes the Liquid Template tag which has format {{ liquid }} 
    If you're lucky enough to use vi, your command is: %s/{{/{{ "{{" }}/g
    Remember to save the file!
 
-7. git commit -a -m "message"
-8. git push
-9. Refresh the http://isocpp.github.io/CppCoreGuidelines/ to verify that the
+6. git commit -a -m "message"
+7. git push
+8. Refresh the http://isocpp.github.io/CppCoreGuidelines/ to verify that the
 build succeeded. If not, check your email! If the page fails to build, you'll 
 get a mail explaining why. 
 

--- a/public/css/custom.css
+++ b/public/css/custom.css
@@ -35,16 +35,21 @@
 
 /** same style for highlighted, non-highlight */
 .cpp.hljs {
-    overflow-x: unset;
-    padding: unset;
+  overflow-x: unset;
+}
+
+/** override poole.css */
+pre code {
+  /* same as hljs */
+  padding: 0.5em;
 }
 
 /** highlight js change colors (overrides style) */
 .hljs-comment {
-    color: #008000;
+  color: #008000;
 }
 .hljs-meta {
-    color: #2b91af;
+  color: #2b91af;
 }
 
 .zip_download_link {


### PR DESCRIPTION
This mainly fixes a slight uglyness of the rendered html on http://isocpp.github.io/CppCoreGuidelines/CppCoreGuidelines for code blocks, you can notice on the left and right side of the codeblocks the letters touch the border between white and grey.

To preview the fix, have a look at my rendering with the patch applied http://tkruse.github.io/CppCoreGuidelines/CppCoreGuidelines.html

Also the front matter for jekyll is optional now: https://blog.github.com/2016-12-09-publishing-with-github-pages-now-as-easy-as-1-2-3/
So I removed it from the md and the INSTRUCTIONS.txt. 