### PR TITLE
Clarify result of lower_bound

### DIFF
--- a/CppCoreGuidelines.md
+++ b/CppCoreGuidelines.md
@@ -13160,7 +13160,7 @@ needed information back to the caller. Therefore, the standard library also offe
     template <class ForwardIterator, class T>
     ForwardIterator lower_bound(ForwardIterator first, ForwardIterator last, const T& val);
 
-`lower_bound` returns an iterator to the first match if any, otherwise `last`.
+`lower_bound` returns an iterator to the first match if any, otherwise to the first element greater than `val`, or `last` if no such element is found.
 
 However, `lower_bound` still doesn't return enough information for all uses, so the standard library also offers
 


### PR DESCRIPTION
To me, the previous formulation made it sound like the return value is always `last` if `val` is not in the range. It seems confusing to me, hence the clarification.