### PR TITLE
Fix example for ES.70

### DIFF
--- a/CppCoreGuidelines.md
+++ b/CppCoreGuidelines.md
@@ -12051,8 +12051,15 @@ Statements control the flow of control (except for function calls and exception 
     void use(int n)
     {
         switch (n) {   // good
-        case 0:   // ...
-        case 7:   // ...
+        case 0:
+            // ...
+            break;
+        case 7:
+            // ...
+            break;
+        default:
+            // ...
+            break;
         }
     }
 


### PR DESCRIPTION
As per #574, fixes the example in ES.70 to emphasize good use of a switch over a sequence of if-else-if statements.