### PR TITLE
Fix broken link to Lifetime paper

### DIFF
--- a/CppCoreGuidelines.md
+++ b/CppCoreGuidelines.md
@@ -20326,7 +20326,7 @@ Most of the concepts below are defined in [the Ranges TS](http://www.open-std.or
 
 ### <a name="SS-gsl-smartptrconcepts"></a>GSL.ptr: Smart pointer concepts
 
-See [Lifetimes paper](https://github.com/isocpp/CppCoreGuidelines/blob/master/docs/Lifetimes%20I%20and%20II%20-%20v0.9.1.pdf).
+See [Lifetime paper](https://github.com/isocpp/CppCoreGuidelines/blob/master/docs/Lifetime.pdf).
 
 # <a name="S-naming"></a>NL: Naming and layout rules
 


### PR DESCRIPTION
The link to the Lifetime paper was pointing a previous version of the PDF with a different name. Therefore, the link was broken. Updated the link to the current version of the paper.