### PR TITLE
Add error management conversion in the calling C++ from C section

### DIFF
--- a/CppCoreGuidelines.md
+++ b/CppCoreGuidelines.md
@@ -18547,13 +18547,28 @@ You can call C from C++:
 
 ##### Example
 
-You can call C++ from C, if needed do not forget to convert the error management for C compilers may expect `noexcept` functions:
+You can call C++ from C:
 
     // in C:
     X call_f(struct Y*, int);
 
     // in C++:
-    extern "C" X call_f(Y* p, int i) noexcept
+    extern "C" X call_f(Y* p, int i)
+    {
+        return p->f(i);   // possibly a virtual function call
+    }
+
+##### Example
+
+Consider who will use your C interface. C, as language, has no support for exceptions. Many compilers allow to compile C enabling exception propagation, but from inside the language it will not be possible to handle those errors. It may not be a problem if the C code will be called by C++, but it can be problematic if the error handling is supposed to be done by C or another language.
+
+You can consider to remap exceptions in another kind of error reporting, as example:
+
+    // in C:
+    X call_f(struct Y*, int);
+
+    // in C++:
+    extern "C" X call_f(Y* p, int i)
     {
         try {
             return p->f(i);   // possibly a virtual function call

--- a/CppCoreGuidelines.md
+++ b/CppCoreGuidelines.md
@@ -18547,15 +18547,19 @@ You can call C from C++:
 
 ##### Example
 
-You can call C++ from C:
+You can call C++ from C, if needed do not forget to convert the error management for C compilers may expect `noexcept` functions:
 
     // in C:
     X call_f(struct Y*, int);
 
     // in C++:
-    extern "C" X call_f(Y* p, int i)
+    extern "C" X call_f(Y* p, int i) noexcept
     {
-        return p->f(i);   // possibly a virtual function call
+        try {
+            return p->f(i);   // possibly a virtual function call
+        } catch(...) {
+            errno = CPPCODEERROR;
+        }
     }
 
 ##### Enforcement


### PR DESCRIPTION
C has no support for the exceptions; basically it means C functions are always `noexcept`. When calling a C++ function from C it is a good idea to convert exceptions in another error management way.

For this reason, this commit updates the example in setting up `errno` in case of exception. It is well possible to expose the error in different ways, but probably it is better describe those in another place.