### PR TITLE
Fixing tagged union example

### DIFF
--- a/CppCoreGuidelines.md
+++ b/CppCoreGuidelines.md
@@ -8608,7 +8608,7 @@ Saving programmers from having to write such code is one reason for including `v
             i = e.i;
             break;
         case Tag::text:
-            new(&s)(e.s);   // placement new: explicit construct
+            new(&s) string(e.s);   // placement new: explicit construct
             type = e.type;
         }
 


### PR DESCRIPTION
It did not compile previously due to missing type specifier on placement new.

[before](https://godbolt.org/z/3qMpyk) [after](https://godbolt.org/z/cONTl1)