### PR TITLE
Remove claims that "constexpr functions are pure"

### DIFF
--- a/CppCoreGuidelines.md
+++ b/CppCoreGuidelines.md
@@ -2601,25 +2601,6 @@ it just guarantees that the function can be evaluated at compile time for consta
 
 ##### Note
 
-`constexpr` functions are pure: they can have no side effects.
-
-    int dcount = 0;
-    constexpr int double(int v)
-    {
-        ++dcount;   // error: attempted side effect from constexpr function
-        return v + v;
-    }
-
-This is usually a very good thing.
-
-When given a non-constant argument, a `constexpr` function can throw.
-If you consider exiting by throwing a side effect, a `constexpr` function isn't completely pure;
-if not, this is not an issue.
-??? A question for the committee: can a constructor for an exception thrown by a `constexpr` function modify state?
-"No" would be a nice answer that matches most practice.
-
-##### Note
-
 Don't try to make all functions `constexpr`.
 Most computation is best done at run time.
 
@@ -2794,16 +2775,6 @@ Pure functions are easier to reason about, sometimes easier to optimize (and eve
 
     template<class T>
     auto square(T t) { return t * t; }
-
-##### Note
-
-`constexpr` functions are pure.
-
-When given a non-constant argument, a `constexpr` function can throw.
-If you consider exiting by throwing a side effect, a `constexpr` function isn't completely pure;
-if not, this is not an issue.
-??? A question for the committee: can a constructor for an exception thrown by a `constexpr` function modify state?
-"No" would be a nice answer that matches most practice.
 
 ##### Enforcement
 


### PR DESCRIPTION
F.4 and F.8 made this erroneous claim as parts of notes which are entirely removed.  In particular, F.4 contained this snippet:
> `constexpr` functions are pure: they can have no side effects.
>
>     int dcount = 0;
>     constexpr int double(int v)
>     {
>         ++dcount;   // error: attempted side effect from constexpr function
>         return v + v;
>     }
Which is full of problems:
  1. the function name is `double`;
  2. the code is ill-formed NDR because there are no values of the argument `v` for which the function is usable in a constant expression; most importantly
  3. the underlying claim that "constexpr functions are pure" is wrong as this counterexample ([Godbolt
     link](https://godbolt.org/z/Cxc20A)) demonstrates:

    int fcount = 0;
    constexpr int f(int v)
    {
        if (v < 0)
            ++fcount;
        return v + v;
    }
