### PR TITLE
Fix typo in ES.102

### DIFF
--- a/CppCoreGuidelines.md
+++ b/CppCoreGuidelines.md
@@ -13059,7 +13059,7 @@ This makes surprises (and bugs) inevitable.
 
 * Flag mixed signed and unsigned arithmetic
 * Flag results of unsigned arithmetic assigned to or printed as signed.
-* Flag unsigned literals (e.g. `-2`) used as container subscripts.
+* Flag negative literals (e.g. `-2`) used as container subscripts.
 * (To avoid noise) Do not flag on a mixed signed/unsigned comparison where one of the arguments is `sizeof` or a call to container `.size()` and the other is `ptrdiff_t`.
 
 


### PR DESCRIPTION
The value -2 is signed, so the word "unsigned" is clearly wrong.  The
text notes that negative subscripts are a source of surprises and
bugs, so the correction to "negative" seems to reflect Bjarne's
original intent.