### PR TITLE
F.21 wording changed to current status of the standard

### DIFF
--- a/CppCoreGuidelines.md
+++ b/CppCoreGuidelines.md
@@ -3087,7 +3087,7 @@ With C++11 we can write this, putting the results directly in existing local var
     tie(iter, success) = my_set.insert("Hello");   // normal return value
     if (success) do_something_with(iter);
 
-With C++17 we should be able to use "structured bindings" to declare and initialize the multiple variables:
+With C++17 we are able to use "structured bindings" to declare and initialize the multiple variables:
 
     if (auto [ iter, success ] = my_set.insert("Hello"); success) do_something_with(iter);
 


### PR DESCRIPTION
F.21 says "With C++17 we should be able to...". That seems to have been written in a time where C++17 was not yet finalised. Today we exactly know what "with C++17 we are able to...".