### PR TITLE
Use `memoizes` instead of `mnemonizes` in the context of caching

### DIFF
--- a/CppCoreGuidelines.md
+++ b/CppCoreGuidelines.md
@@ -16256,7 +16256,7 @@ e.g. because it is in a library that you cannot modify.
 
 A `const` member function can modify the value of an object that is `mutable` or accessed through a pointer member.
 A common use is to maintain a cache rather than repeatedly do a complicated computation.
-For example, here is a `Date` that caches (mnemonizes) its string representation to simplify repeated uses:
+For example, here is a `Date` that caches (memoizes) its string representation to simplify repeated uses:
 
     class Date {
     public:

--- a/scripts/hunspell/isocpp.dic
+++ b/scripts/hunspell/isocpp.dic
@@ -304,6 +304,7 @@ memcmp
 memmove
 memoization
 memoized
+memoizes
 memset
 metameta
 metaprogram


### PR DESCRIPTION
While apparently, 'mnemonizes' is a word, I don't think it's the best choice here.