### PR TITLE
MD typo fix

### DIFF
--- a/CppCoreGuidelines.md
+++ b/CppCoreGuidelines.md
@@ -1,4 +1,4 @@
-d# <a name="main"></a>C++ Core Guidelines
+# <a name="main"></a>C++ Core Guidelines
 
 March 7, 2019
 


### PR DESCRIPTION
There was an extra character in front of the markdown title.