### PR TITLE
Added bad and good example to NR.5 in CppCoreGuidelines.md

### DIFF
--- a/CppCoreGuidelines.md
+++ b/CppCoreGuidelines.md
@@ -20052,7 +20052,7 @@ and errors (when we didn't deal correctly with semi-constructed objects consiste
         bool Init()
         {
             // invariant checks
-            if (mx <= 0 || my <= 0 || mx % 2 != 0 || my % 2 != 0) {
+            if (mx <= 0 || my <= 0) {
                 return false;
             }
             if (data) {
@@ -20069,10 +20069,10 @@ and errors (when we didn't deal correctly with semi-constructed objects consiste
         }
     };
     
-    Picture picture(3, 5); // not ready-to-use picture here
+    Picture picture(100, 0); // not ready-to-use picture here
     // this will fail..
     if (!picture.Init()) {
-        puts("Error, invlaid picture");
+        puts("Error, invalid picture");
     }
     // now have a invalid picture object instance.
 
@@ -20080,21 +20080,19 @@ and errors (when we didn't deal correctly with semi-constructed objects consiste
 
     class Picture
     {
-        int mx;
-        int my;
+        size_t mx;
+        size_t my;
         vector<char> data;
     
-        inline int check_size(int s)
+        inline size_t check_size(size_t s)
         {
             // invariant check
-            if (s <= 0  || s % 2 != 0) {
-                throw std::invalid_argument("wrong size for picture");
-            }
+            Expects(s > 0);
             return s;
         }
     
     public:
-        Picture(int x, int y)
+        Picture(size_t x, size_t y) // even more better would be a class Size2D as one single parameter
             : mx(check_size(x))
             , my(check_size(y))
             // now we know x and y have a valid size
@@ -20102,22 +20100,14 @@ and errors (when we didn't deal correctly with semi-constructed objects consiste
         {
             // picture is ready-to-use
         }
-        ~Picture() = default; // nothing to do here.
+        // compiler generated dtor does the job. (also see C.21)
     };
     
-    try {
-        Picture picture(3, 5);
-        // not reach here...
-    } catch(std::exception const & ex) {
-        puts(ex.what());
-    }
+    Picture picture(100, 100);
+    // picture is ready-to-use here...
     
-    try {
-        Picture picture(4, 8);
-        // picture is ready-to-use here...
-    } catch(std::exception const & ex) {
-        puts(ex.what());
-    }
+    Picture picture(100, 0); // not a valid size, exception will be thrown
+    // not reach here...
 
 ##### Alternative
 

--- a/CppCoreGuidelines.md
+++ b/CppCoreGuidelines.md
@@ -20092,7 +20092,7 @@ and errors (when we didn't deal correctly with semi-constructed objects consiste
         }
     
     public:
-        Picture(size_t x, size_t y) // even more better would be a class Size2D as one single parameter
+        Picture(size_t x, size_t y) // even more better would be a class for a 2D Size as one single parameter
             : mx(check_size(x))
             , my(check_size(y))
             // now we know x and y have a valid size

--- a/CppCoreGuidelines.md
+++ b/CppCoreGuidelines.md
@@ -20033,10 +20033,11 @@ and errors (when we didn't deal correctly with semi-constructed objects consiste
 
     class Picture
     {
-        int mx, my;
+        int mx; 
+        int my;
         char * data;
     public:
-        Picture( int x, int y ) 
+        Picture(int x, int y) 
         {
             mx = x,
             my = y;
@@ -20051,27 +20052,27 @@ and errors (when we didn't deal correctly with semi-constructed objects consiste
         bool Init()
         {
             // invariant checks
-            if( mx <= 0 || my <= 0 || mx % 2 != 0 || my % 2 != 0 ) {
+            if (mx <= 0 || my <= 0 || mx % 2 != 0 || my % 2 != 0) {
                 return false;
             }
-            if( data ) {
+            if (data) {
                 return false;
             }
-            data = (char*)malloc( x*y*sizeof(int) );
+            data = (char*) malloc(x*y*sizeof(int));
             return data != nullptr;
         }
     
         bool Cleanup()
         {
-            if(data) free(data);
+            if (data) free(data);
             data = nullptr;
         }
     };
     
-    Picture picture( 3, 5 ); // not ready-to-use picture here
+    Picture picture(3, 5); // not ready-to-use picture here
     // this will fail..
-    if( !picture.Init() ) {
-        puts( "Error, invlaid picture");
+    if (!picture.Init()) {
+        puts("Error, invlaid picture");
     }
     // now have a invalid picture object instance.
     
@@ -20079,24 +20080,25 @@ and errors (when we didn't deal correctly with semi-constructed objects consiste
 
     class Picture
     {
-        int mx, my;
+        int mx;
+        int my;
         vector<char> data;
     
-        inline int check_size( int s )
+        inline int check_size(int s)
         {
             // invariant check
-            if( s <= 0  || s % 2 != 0 ) {
-                throw std::invalid_argument( "wrong size for picture" );
+            if (s <= 0  || s % 2 != 0) {
+                throw std::invalid_argument("wrong size for picture");
             }
             return s;
         }
     
     public:
-        Picture( int x, int y )
-            : mx( check_size(x) )
-            , my( check_size(y) )
+        Picture(int x, int y)
+            : mx(check_size(x))
+            , my(check_size(y))
             // now we know x and y have a valid size
-            , data( mx * my * sizeof(int) ) // will throw std::bad_alloc on error
+            , data(mx * my * sizeof(int)) // will throw std::bad_alloc on error
         {
             // picture is ready-to-use
         }
@@ -20104,17 +20106,17 @@ and errors (when we didn't deal correctly with semi-constructed objects consiste
     };
     
     try {
-        Picture picture( 3, 5 );
+        Picture picture(3, 5);
         // not reach here...
-    } catch( std::exception const & ex ) {
-        puts( ex.what() );
+    } catch(std::exception const & ex) {
+        puts(ex.what());
     }
     
     try {
-        Picture picture( 4, 8 );
+        Picture picture(4, 8);
         // picture is ready-to-use here...
-    } catch( std::exception const & ex ) {
-        puts( ex.what() );
+    } catch(std::exception const & ex) {
+        puts(ex.what());
     }
 
 ##### Alternative

--- a/CppCoreGuidelines.md
+++ b/CppCoreGuidelines.md
@@ -20029,9 +20029,93 @@ Following this rule leads to weaker invariants,
 more complicated code (having to deal with semi-constructed objects),
 and errors (when we didn't deal correctly with semi-constructed objects consistently).
 
-##### Example
+##### Example, bad
 
-    ???
+    class Picture
+    {
+        int mx, my;
+        char * data;
+    public:
+        Picture( int x, int y ) 
+        {
+            mx = x,
+            my = y;
+            data = nullptr;
+        }
+    
+        ~Picture()
+        {
+            Cleanup();
+        }
+    
+        bool Init()
+        {
+            // invariant checks
+            if( mx <= 0 || my <= 0 || mx % 2 != 0 || my % 2 != 0 ) {
+                return false;
+            }
+            if( data ) {
+                return false;
+            }
+            data = (char*)malloc( x*y*sizeof(int) );
+            return data != nullptr;
+        }
+    
+        bool Cleanup()
+        {
+            if(data) free(data);
+            data = nullptr;
+        }
+    };
+    
+    Picture picture( 3, 5 ); // not ready-to-use picture here
+    // this will fail..
+    if( !picture.Init() ) {
+        puts( "Error, invlaid picture");
+    }
+    // now have a invalid picture object instance.
+    
+##### Example, good
+
+    class Picture
+    {
+        int mx, my;
+        vector<char> data;
+    
+        inline int check_size( int s )
+        {
+            // invariant check
+            if( s <= 0  || s % 2 != 0 ) {
+                throw std::invalid_argument( "wrong size for picture" );
+            }
+            return s;
+        }
+    
+    public:
+        Picture( int x, int y )
+            : mx( check_size(x) )
+            , my( check_size(y) )
+            // now we know x and y have a valid size
+            , data( mx * my * sizeof(int) ) // will throw std::bad_alloc on error
+        {
+            // picture is ready-to-use
+        }
+        ~Picture() = default; // nothing to do here.
+    };
+    
+    try {
+        Picture picture( 3, 5 );
+        // not reach here...
+    } catch( std::exception const & ex ) {
+        puts( ex.what() );
+    }
+    
+    try {
+        Picture picture( 4, 8 );
+        // picture is ready-to-use here...
+    } catch( std::exception const & ex ) {
+        puts( ex.what() );
+    }
 
 ##### Alternative
 

--- a/CppCoreGuidelines.md
+++ b/CppCoreGuidelines.md
@@ -20104,10 +20104,10 @@ and errors (when we didn't deal correctly with semi-constructed objects consiste
         // compiler generated dtor does the job. (also see C.21)
     };
     
-    Picture picture(100, 100);
+    Picture picture1(100, 100);
     // picture is ready-to-use here...
     
-    Picture picture(100, 0); // not a valid size, exception will be thrown
+    Picture picture2(100, 0); // not a valid size, exception will be thrown
     // not reach here...
 
 ##### Alternative

--- a/CppCoreGuidelines.md
+++ b/CppCoreGuidelines.md
@@ -20033,7 +20033,7 @@ and errors (when we didn't deal correctly with semi-constructed objects consiste
 
     class Picture
     {
-        int mx; 
+        int mx;
         int my;
         char * data;
     public:

--- a/CppCoreGuidelines.md
+++ b/CppCoreGuidelines.md
@@ -20037,7 +20037,7 @@ and errors (when we didn't deal correctly with semi-constructed objects consiste
         int my;
         char * data;
     public:
-        Picture(int x, int y) 
+        Picture(int x, int y)
         {
             mx = x,
             my = y;

--- a/CppCoreGuidelines.md
+++ b/CppCoreGuidelines.md
@@ -20062,7 +20062,7 @@ and errors (when we didn't deal correctly with semi-constructed objects consiste
             return data != nullptr;
         }
     
-        bool Cleanup()
+        void Cleanup()
         {
             if (data) free(data);
             data = nullptr;

--- a/CppCoreGuidelines.md
+++ b/CppCoreGuidelines.md
@@ -20075,7 +20075,7 @@ and errors (when we didn't deal correctly with semi-constructed objects consiste
         puts("Error, invlaid picture");
     }
     // now have a invalid picture object instance.
-    
+
 ##### Example, good
 
     class Picture

--- a/CppCoreGuidelines.md
+++ b/CppCoreGuidelines.md
@@ -20092,7 +20092,8 @@ and errors (when we didn't deal correctly with semi-constructed objects consiste
         }
     
     public:
-        Picture(size_t x, size_t y) // even more better would be a class for a 2D Size as one single parameter
+        // even more better would be a class for a 2D Size as one single parameter
+        Picture(size_t x, size_t y)
             : mx(check_size(x))
             , my(check_size(y))
             // now we know x and y have a valid size

--- a/CppCoreGuidelines.md
+++ b/CppCoreGuidelines.md
@@ -20084,7 +20084,7 @@ and errors (when we didn't deal correctly with semi-constructed objects consiste
         size_t my;
         vector<char> data;
     
-        inline size_t check_size(size_t s)
+        static size_t check_size(size_t s)
         {
             // invariant check
             Expects(s > 0);
@@ -20107,7 +20107,9 @@ and errors (when we didn't deal correctly with semi-constructed objects consiste
     Picture picture1(100, 100);
     // picture is ready-to-use here...
     
-    Picture picture2(100, 0); // not a valid size, exception will be thrown
+    // not a valid size for y,
+    // default contract violation behavior will call std::terminate then
+    Picture picture2(100, 0);
     // not reach here...
 
 ##### Alternative


### PR DESCRIPTION
Hello, 
I added a bad and good example to NR.5 Don’t: Don’t do substantive work in a constructor; instead use two-phase initialization.
I think it could be suitable. If you think it illustrates the reason for the "don't" rule well, I would be happy if you integrate the change.
Anyway I would be happy about any thoughts and comments.
Thank you very much.
Florian