### PR TITLE
ES.42: index in an example was not declared

### DIFF
--- a/CppCoreGuidelines.md
+++ b/CppCoreGuidelines.md
@@ -11376,6 +11376,7 @@ Use a range-`for`:
     void f3()
     {
         int arr[COUNT];
+        int i = 0;
         for (auto& e : arr)
              e = i++;
     }


### PR DESCRIPTION
There was an uninitialized variable `i`