### PR TITLE
Tighten up CP.1

### DIFF
--- a/CppCoreGuidelines.md
+++ b/CppCoreGuidelines.md
@@ -13796,7 +13796,7 @@ Concurrency and parallelism rule summary:
 
 ##### Reason
 
-It's hard to be certain that concurrency isn't used now or won't be used be sometime in the future.
+It's hard to be certain that concurrency isn't used now or won't be used sometime in the future.
 Code gets reused.
 Libraries not using threads may be used from some other part of a program that does use threads.
 Note that this rule applies most urgently to library code and least urgently to stand-alone applications.

--- a/CppCoreGuidelines.md
+++ b/CppCoreGuidelines.md
@@ -13819,13 +13819,10 @@ However, over time, code fragments can turn up in unexpected places.
         return result;
     }
 
-This example uses a simplistic caching strategy that avoids an expensive `computation` call when consecutive `cached_computation` calls are made with identical `x` parameters.
-Although `cached_computation` works as intended in a single-threaded environment, its two `static` variables result in data races and thus undefined behavior in a multi-threaded environment.
-
 There are several ways that this example could be made safe for a multi-threaded environment:
 
 * Delegate concurrency concerns upwards to the caller.
-* Mark the `static` variables as `thread_local` (which would prevent cache hit performance gains across thread boundaries).
+* Mark the `static` variables as `thread_local` (which might make caching less effective).
 * Implement concurrency control, for example, protecting the two `static` variables with a `static` lock (which might reduce performance).
 * Have the caller provide the memory to be used for the cache, thereby delegating both memory allocation and concurrency concerns upwards to the caller.
 * Refuse to build and/or run in a multi-threaded environment.


### PR DESCRIPTION
* balanced verb usage in first sentence
* changed third sentence to "libraries not using threads", as I
  believe this was the original author's intended meaning.
* clarified "this" in fourth sentence
* cut wordiness of "thanks to the magic of cut-and-paste", as it
  added no value
* changed "Example" heading to "Example, bad"
* added "bad:" comment above statics in the example
* added an explanatory sentence immediately after the example
* changed "works perfectly in a single-threaded" after example to
  "works as intended in a single threaded".  Also balanced the
  structure of the two comma separated phrases inside this sentence.
* strengthened parenthetical explanation in second bullet of "could
  be made safe" section