### PR TITLE
Fix #1425: C.120 good example violates C.128

### DIFF
--- a/CppCoreGuidelines.md
+++ b/CppCoreGuidelines.md
@@ -6788,8 +6788,8 @@ Do *not* use inheritance when simply having a data member will do. Usually this 
     };
 
     class PushButton : public AbstractButton {
-        virtual void render() const override;
-        virtual void onClick() override;
+        void render() const override;
+        void onClick() override;
         // ...
     };
 


### PR DESCRIPTION
Minor correction: C.120 has a good example which violates C.128 by
specifying both `virtual` and `override` for methods.