### PR TITLE
Add SF.12 - Use the quoted or angle bracket form of `#include`  to identify the scope of dependencies

### DIFF
--- a/CppCoreGuidelines.md
+++ b/CppCoreGuidelines.md
@@ -18603,6 +18603,7 @@ Source file rule summary:
 * [SF.9: Avoid cyclic dependencies among source files](#Rs-cycles)
 * [SF.10: Avoid dependencies on implicitly `#include`d names](#Rs-implicit)
 * [SF.11: Header files should be self-contained](#Rs-contained)
+* [SF.12: Use the quoted or angle bracket form of `#include`  to identify the scope of dependencies](#Rs-incscope)
 
 * [SF.20: Use `namespace`s to express logical structure](#Rs-namespace)
 * [SF.21: Don't use an unnamed (anonymous) namespace in a header](#Rs-unnamed)
@@ -19030,6 +19031,28 @@ Failing to follow this results in difficult to diagnose errors for clients of a 
 ##### Enforcement
 
 A test should verify that the header file itself compiles or that a cpp file which only includes the header file compiles.
+
+### <a name="Rs-incscope"></a>SF.12: Use the quoted or angle bracket form of `#include`  to identify the scope of dependencies
+
+##### Reason
+
+To understand dependencies it is important to know where included files come from. Given the different search algorithms, 
+the angle form (`<>`) identifies global scope, the quoted (`""`), files within the project (files co-located with use of the include statement).
+
+##### Example
+
+    #include <string>       // From the standard library, referenced via INCLUDES, use the <> form
+    #include "helpers.h"    // A peer of the file including it, use "" form
+
+##### Note
+
+Failing to follow this results in difficult to diagnose errors due to picking up the wrong file by incorrectly specifying the scope when it is included.
+
+Library creators should put their headers in a folder and have clients include those files using the relative path `#include <some_library/common.h>`
+
+##### Enforcement
+
+A test should verify that the headers referenced are found via INCLUDES for the `<>` form and in the directory next to the including file for `""`.
 
 ### <a name="Rs-namespace"></a>SF.20: Use `namespace`s to express logical structure
 


### PR DESCRIPTION
content should speak for itself