### PR TITLE
C.102: format note as text, not as code

### DIFF
--- a/CppCoreGuidelines.md
+++ b/CppCoreGuidelines.md
@@ -6658,7 +6658,7 @@ resource management problems.
         return sv;
     }
 
-    A user can reasonably assume that returning a standard-like container is cheap.
+A user can reasonably assume that returning a standard-like container is cheap.
 
 ##### Enforcement
 


### PR DESCRIPTION
The last sentence in C.102 is formatted as code but looks like it should be formatted as text.