### PR TITLE
C.145: add "see also" C.67

### DIFF
--- a/CppCoreGuidelines.md
+++ b/CppCoreGuidelines.md
@@ -7685,6 +7685,10 @@ You can safely access a named polymorphic object in the scope of its definition,
         d.f();   // OK
     }
 
+##### See also
+
+[A polymorphic class should suppress copying](#Rc-copy-virtual)
+
 ##### Enforcement
 
 Flag all slicing.


### PR DESCRIPTION
C.145 says what not to do and how the compiler can warn us. But the "see also C.67" gives a hint what the programmer can do to prevent slicing effectively.