### PR TITLE
Travis CI: The sudo tag is now deprecated in Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,5 @@
 # This is the configuration for Travis CI, a free github-integrated service that runs this script for each pull request (if configured)
 
-# Be nice to travis, allow docker builds, must not use sudo below
-sudo: false
-
 # provides gcc, clang, make, scons, cmake
 language: c++
 


### PR DESCRIPTION
 [Travis are now recommending removing the __sudo__ tag](https://blog.travis-ci.com/2018-11-19-required-linux-infrastructure-migration).

"_If you currently specify __sudo: false__ in your __.travis.yml__, we recommend removing that configuration_"