### PR TITLE
make the sample in Sd-factory and C.50 compileable (closes #1205, #1488)

### DIFF
--- a/CppCoreGuidelines.md
+++ b/CppCoreGuidelines.md
@@ -5622,7 +5622,7 @@ The return type of the factory should normally be `unique_ptr` by default; if so
     public:
         B() {
             /* ... */
-            f();   // BAD: virtual call in constructor, see Item 49.1 in [SuttAlex05](#SuttAlex05)
+            f(); // BAD: C.82: Don't call virtual functions in constructors and destructors
             /* ... */
         }
 
@@ -21502,7 +21502,7 @@ Here is an example of the last option:
     public:
         B() {
             /* ... */
-            f();   // BAD: virtual call in constructor, see Item 49.1 in [SuttAlex05](#SuttAlex05)
+            f(); // BAD: C.82: Don't call virtual functions in constructors and destructors
             /* ... */
         }
 

--- a/CppCoreGuidelines.md
+++ b/CppCoreGuidelines.md
@@ -5620,7 +5620,11 @@ The return type of the factory should normally be `unique_ptr` by default; if so
 
     class B {
     public:
-        B() { /* ... */ f(); /* ... */ }   // BAD: virtual call in constructor
+        B() {
+            /* ... */
+            f();   // BAD: virtual call in constructor, see Item 49.1 in [SuttAlex05](#SuttAlex05)
+            /* ... */
+        }
 
         virtual void f() = 0;
     };
@@ -21496,7 +21500,11 @@ Here is an example of the last option:
 
     class B {
     public:
-        B() { /* ... */ f(); /* ... */ }   // BAD: virtual call in constructor
+        B() {
+            /* ... */
+            f();   // BAD: virtual call in constructor, see Item 49.1 in [SuttAlex05](#SuttAlex05)
+            /* ... */
+        }
 
         virtual void f() = 0;
     };
@@ -21546,7 +21554,7 @@ Here is an example of the last option:
 This design requires the following discipline:
 
 * Derived classes such as `D` must not expose a publicly callable constructor. Otherwise, `D`'s users could create `D` objects that don't invoke `post_initialize`.
-* Allocation is limited to `operator new`. `B` can, however, override `new` (see Items 45 and 46).
+* Allocation is limited to `operator new`. `B` can, however, override `new` (see Items 45 and 46 in [SuttAlex05](#SuttAlex05)).
 * `D` must define a constructor with the same parameters that `B` selected. Defining several overloads of `create` can assuage this problem, however; and the overloads can even be templated on the argument types.
 
 If the requirements above are met, the design guarantees that `post_initialize` has been called for any fully constructed `B`-derived object. `post_initialize` doesn't need to be virtual; it can, however, invoke virtual functions freely.

--- a/CppCoreGuidelines.md
+++ b/CppCoreGuidelines.md
@@ -21506,7 +21506,8 @@ Here is an example of the last option:
         class Token {};
 
     public:
-        // constructor needs to be public so that make_shared can access it. protected access level is gained by requiring a Token.
+        // constructor needs to be public so that make_shared can access it.
+		// protected access level is gained by requiring a Token.
         explicit B(Token) { /* ... */ }  // create an imperfectly initialized object
         virtual void f() = 0;
 
@@ -21530,7 +21531,8 @@ Here is an example of the last option:
         class Token {};
 
     public:
-        // constructor needs to be public so that make_shared can access it. protected access level is gained by requiring a Token.
+        // constructor needs to be public so that make_shared can access it.
+		// protected access level is gained by requiring a Token.
         explicit D(Token) : B{ B::Token{} } {}
         void f() override { /* ...  */ };
 

--- a/CppCoreGuidelines.md
+++ b/CppCoreGuidelines.md
@@ -21507,7 +21507,7 @@ Here is an example of the last option:
 
     public:
         // constructor needs to be public so that make_shared can access it.
-		// protected access level is gained by requiring a Token.
+        // protected access level is gained by requiring a Token.
         explicit B(Token) { /* ... */ }  // create an imperfectly initialized object
         virtual void f() = 0;
 
@@ -21532,7 +21532,7 @@ Here is an example of the last option:
 
     public:
         // constructor needs to be public so that make_shared can access it.
-		// protected access level is gained by requiring a Token.
+        // protected access level is gained by requiring a Token.
         explicit D(Token) : B{ B::Token{} } {}
         void f() override { /* ...  */ };
 

--- a/CppCoreGuidelines.md
+++ b/CppCoreGuidelines.md
@@ -5663,7 +5663,7 @@ The return type of the factory should normally be `unique_ptr` by default; if so
 
     shared_ptr<D> p = D::create<D>();  // creating a D object
 
-`make_shared` requires that the constructor is public. By requiring a protected `Token` the constructur cannot be publicly called anymore, so we avoid an incompletely constructed object escaping into the wild.
+`make_shared` requires that the constructor is public. By requiring a protected `Token` the constructor cannot be publicly called anymore, so we avoid an incompletely constructed object escaping into the wild.
 By providing the factory function `create()`, we make construction (on the free store) convenient.
 
 ##### Note


### PR DESCRIPTION
- make the sample in Sd-factory compileable
  - fixed wrong capitalization: create/Create -> create
  - `make_shared` cannot access protected constructors, so made them public. To still have access protection introduced a protected `class Token` in each class. That token can only be created by the class itself (and derived classes) and needs to be passed to the constructor.
- changed order: `public` first, then `protected`
- same sample for C.50 and Sd-factory
- removed spurious "see Item 49.1" as it is unclear what this means