### PR TITLE
Update `Rper-simple` example comment

### DIFF
--- a/CppCoreGuidelines.md
+++ b/CppCoreGuidelines.md
@@ -13390,7 +13390,7 @@ Simple code can be very fast. Optimizers sometimes do marvels with simple code
 
 ##### Example, bad
 
-    // intended to be faster, but is actually slower
+    // intended to be faster, but is often slower
 
     vector<uint8_t> v(100000);
 


### PR DESCRIPTION
The 'complex' example is actually a bit faster with [clang](http://quick-bench.com/DrXvcvhjS1zDmMkgxrzIjbMByYA) 8 /w -O3, and equally fast as the 'simple' example with [gcc](http://quick-bench.com/03VXPgDSxiMAmZMItiEA0iwTJgM) 9.1 /w -O3

On GCC, the 'simple' example compiles to: 

```
.L3:
        movdqu  xmm0, XMMWORD PTR [rax]
        add     rax, 16
        pxor    xmm0, xmm1
        movups  XMMWORD PTR [rax-16], xmm0
        cmp     rax, rbx
        jne     .L3
```
... and the 'complex' example compiles to the same. 
