### PR TITLE
Clarify that GSL semi-specification of some types does not reflect actual support of them

### DIFF
--- a/CppCoreGuidelines.md
+++ b/CppCoreGuidelines.md
@@ -20533,6 +20533,9 @@ Where desirable, they can be "instrumented" with additional functionality (e.g.,
 These Guidelines assume a `variant` type, but this is not currently in GSL.
 Eventually, use [the one voted into C++17](http://www.open-std.org/jtc1/sc22/wg21/docs/papers/2016/p0088r3.html).
 
+Some of the types listed below may not be supported in the library you use due to technical reasons such as limitations in the current versions of C++.
+Therefore, please consult your GSL documentation to find out more.
+
 Summary of GSL components:
 
 * [GSL.view: Views](#SS-views)


### PR DESCRIPTION
When I was reading the chapter about [GSL](https://github.com/isocpp/CppCoreGuidelines/blob/master/CppCoreGuidelines.md#gsl-guidelines-support-library) I was quite confused by the current listing of some entities. For example, the entire component about Concepts will simply not work unless someone writes non-portable compiler / extensions. Another example is use of unrecognised attributes - before C++17 it's technically an error.
I believe it should be stated that some constructs are yet unavailable in the language and users should always consult the GSL version of their preference to find out what is supported. Otherwise, we get quite premature specification that little to no people can use in their code.