### PR TITLE
Fix discussion link in C.36

### DIFF
--- a/CppCoreGuidelines.md
+++ b/CppCoreGuidelines.md
@@ -4998,7 +4998,7 @@ Many have tried to devise a fool-proof scheme for dealing with failure in destru
 None have succeeded to come up with a general scheme.
 This can be a real practical problem: For example, what about a socket that won't close?
 The writer of a destructor does not know why the destructor is called and cannot "refuse to act" by throwing an exception.
-See [discussion](#Sd-dtor).
+See [discussion](#Sd-never-fail).
 To make the problem worse, many "close/release" operations are not retryable.
 If at all possible, consider failure to close/cleanup a fundamental design error and terminate.
 


### PR DESCRIPTION
The link to discussion on ```C.36: A destructor may not fail``` was linking to ```Discussion: Make base class destructors public and virtual, or protected and nonvirtual``` which seems only peripherally related to the topic. I presume the intent was instead to link to the discussion ```Discussion: Destructors, deallocation, and swap must never fail```.