### PR TITLE
Fix inconsistency

### DIFF
--- a/CppCoreGuidelines.md
+++ b/CppCoreGuidelines.md
@@ -8821,7 +8821,7 @@ Instead use an `enum class`:
     void Print_color(int color);
 
     enum class Web_color { red = 0xFF0000, green = 0x00FF00, blue = 0x0000FF };
-    enum class Product_info { red = 0, purple = 1, blue = 2 };
+    enum class Product_info { Red = 0, Purple = 1, Blue = 2 };
 
     Web_color webby = Web_color::blue;
     Print_color(webby);  // Error: cannot convert Web_color to int.


### PR DESCRIPTION
Fixes inconsistency in "Enum.3: Prefer class enums over "plain" enums".

Second example (current version):
```
void Print_color(int color);

enum class Web_color { red = 0xFF0000, green = 0x00FF00, blue = 0x0000FF };
enum class Product_info { red = 0, purple = 1, blue = 2 };

Web_color webby = Web_color::blue;
Print_color(webby);             // Error: cannot convert Web_color to int.
Print_color(Product_info::Red); // Error: cannot convert Product_info to int.
```

has an error in the last line => enum has no member "Red". Although the example tries to show something else. This fix just renames the values in `Product_info`.