### PR TITLE
Added example to CP.61: Use an async() to spawn a concurrent task

### DIFF
--- a/CppCoreGuidelines.md
+++ b/CppCoreGuidelines.md
@@ -14924,35 +14924,27 @@ There is no explicit locking and both correct (value) return and error (exceptio
 
 ##### Example
 
-    class Moonphase_error : public std::exception
-    {};
-
-    int fun(int i) noexcept
+    int read_value(const std::string& filename)
     {
-        return i + 2;
+        std::ifstream in(filename);
+        in.exceptions(std::ifstream::failbit);
+        int value;
+        in >> value;
+        return value;
     }
 
-    int fun_ex()
-    {
-        // ...
-        throw Moonphase_error{};
-        // ...
-    }
 
     void async_example()
     {
-        auto f = std::async(std::launch::async, fun, 10);
-
-        std::cout << f.get() << '\n';
-
         try
         {
-            auto fe = std::async(std::launch::async, fun_ex);
-            auto i = fe.get(); // this call will thow a Moonphase_error exception
+            auto v1 = std::async(std::launch::async, read_value, "v1.txt"); 
+            auto v2 = std::async(std::launch::async, read_value, "v2.txt");
+            std::cout << v1.get() + v2.get() << '\n';
         }
-        catch (const Moonphase_error&)
+        catch (std::ios_base::failure & fail) 
         {
-            std::cout << "Moonphase error\n";
+            // handle exception here
         }
     }
     

--- a/CppCoreGuidelines.md
+++ b/CppCoreGuidelines.md
@@ -14924,8 +14924,38 @@ There is no explicit locking and both correct (value) return and error (exceptio
 
 ##### Example
 
-    ???
+    class Moonphase_error : public std::exception
+    {};
 
+    int fun(int i) noexcept
+    {
+        return i + 2;
+    }
+
+    int fun_ex()
+    {
+        // ...
+        throw Moonphase_error{};
+        // ...
+    }
+
+    void async_example()
+    {
+        auto f = std::async(std::launch::async, fun, 10);
+
+        std::cout << f.get() << '\n';
+
+        try
+        {
+            auto fe = std::async(std::launch::async, fun_ex);
+            auto i = fe.get(); // this call will thow a Moonphase_error exception
+        }
+        catch (const Moonphase_error&)
+        {
+            std::cout << "Moonphase error\n";
+        }
+    }
+    
 ##### Note
 
 Unfortunately, `async()` is not perfect.


### PR DESCRIPTION
Added example to CP.61: Use an async() to spawn a concurrent task