### PR TITLE
C.22 Fixes a mistake in the code example not making a deep copy

### DIFF
--- a/CppCoreGuidelines.md
+++ b/CppCoreGuidelines.md
@@ -4701,7 +4701,7 @@ Users will be surprised if copy/move construction and copy/move assignment do lo
         };
         shared_ptr<Impl> p;
     public:
-        Silly(const Silly& a) : p{a.p} { *p = *a.p; }   // deep copy
+        Silly(const Silly& a) : p(make_shared<Impl>()) { *p = *a.p; }   // deep copy
         Silly& operator=(const Silly& a) { p = a.p; }   // shallow copy
         // ...
     };


### PR DESCRIPTION
A code example in C.22 aims to illustrate inconsistent behaviour with a copy ctor making a deep copy and a move ctor making a shallow copy.

Yet the copy ctor actually make a shallow copy too (please see: https://godbolt.org/z/Ssx6Su), because it copies the shared_ptr (share semantic) instead of constructing a new shared_ptr.

This fixes the sample by creating a new shared_ptr, assuming Silly::Impl has a default ctor.