### PR TITLE
Enforcing ES.23 on example code

### DIFF
--- a/CppCoreGuidelines.md
+++ b/CppCoreGuidelines.md
@@ -503,8 +503,8 @@ This loop is a restricted form of `std::find`:
         string val;
         cin >> val;
         // ...
-        int index = -1;                    // bad, plus should use gsl::index
-        for (int i = 0; i < v.size(); ++i) {
+        int index{ -1 };                    // bad, plus should use gsl::index
+        for (int i{ 0 }; i < v.size(); ++i) {
             if (v[i] == val) {
                 index = i;
                 break;
@@ -596,7 +596,7 @@ Unless the intent of some code is stated (e.g., in names or comments), it is imp
 
 ##### Example
 
-    gsl::index i = 0;
+    gsl::index i{ 0 };
     while (i < v.size()) {
         // ... do something with v[i] ...
     }
@@ -692,8 +692,8 @@ You don't need to write error handlers for errors caught at compile time.
 ##### Example
 
     // Int is an alias used for integers
-    int bits = 0;         // don't: avoidable code
-    for (Int i = 1; i; i <<= 1)
+    int bits{ 0 };         // don't: avoidable code
+    for (Int i{ 1 }; i; i <<= 1)
         ++bits;
     if (bits < 32)
         cerr << "Int too small\n";
@@ -792,7 +792,7 @@ We need to pass the pointer and the number of elements as an integral object:
     {
         vector<int> v(n);
         f4(v);                     // pass a reference, retain ownership
-        f4(span<int>{v});          // pass a view, retain ownership
+        f4(span<int>{ v });          // pass a view, retain ownership
     }
 
 This design carries the number of elements along as an integral part of an object, so that errors are unlikely and dynamic (run-time) checking is always feasible, if not always affordable.
@@ -844,12 +844,12 @@ Avoid errors leading to (possibly unrecognized) wrong results.
 
     void increment1(int* p, int n)    // bad: error-prone
     {
-        for (int i = 0; i < n; ++i) ++p[i];
+        for (int i{ 0 }; i < n; ++i) ++p[i];
     }
 
     void use1(int m)
     {
-        const int n = 10;
+        const int n{ 10 };
         int a[n] = {};
         // ...
         increment1(a, m);   // maybe typo, maybe m <= n is supposed
@@ -869,10 +869,10 @@ We could check earlier and improve the code:
 
     void use2(int m)
     {
-        const int n = 10;
+        const int n{ 10 };
         int a[n] = {};
         // ...
-        increment2({a, m});    // maybe typo, maybe m <= n is supposed
+        increment2({ a, m });    // maybe typo, maybe m <= n is supposed
         // ...
     }
 
@@ -881,7 +881,7 @@ If all we had was a typo so that we meant to use `n` as the bound, the code coul
 
     void use3(int m)
     {
-        const int n = 10;
+        const int n{ 10 };
         int a[n] = {};
         // ...
         increment2(a);   // the number of elements of a need not be repeated
@@ -898,13 +898,13 @@ Don't repeatedly check the same value. Don't pass structured data as strings:
 
     void user1(const string& date)    // manipulate date
     {
-        auto d = extract_date(date);
+        auto d{ extract_date(date) };
         // ...
     }
 
     void user2()
     {
-        Date d = read_date(cin);
+        Date d{ read_date(cin) };
         // ...
         user1(d.to_string());
         // ...
@@ -922,9 +922,10 @@ There are cases where checking early is dumb because you may not ever need the v
         float y;
         float z;
         float e;
+
     public:
-        Jet(float x, float y, float z, float e)
-            :x(x), y(y), z(z), e(e)
+        Jet(float , float y, float z, float e)
+            :x{ x }, y{ y }, z{ z }, e{ e }
         {
             // Should I check here that the values are physically meaningful?
         }
@@ -961,7 +962,7 @@ This is particularly important for long-running programs, but is an essential pi
 
     void f(char* name)
     {
-        FILE* input = fopen(name, "r");
+        FILE* input{ fopen(name, "r") };
         // ...
         if (something) return;   // bad: if something == true, a file handle is leaked
         // ...
@@ -972,7 +973,7 @@ Prefer [RAII](#Rr-raii):
 
     void f(char* name)
     {
-        ifstream input {name};
+        ifstream input{ name };
         // ...
         if (something) return;   // OK: no leak
         // ...
@@ -1022,29 +1023,29 @@ Time and space that you spend well to achieve a goal (e.g., speed of development
         string s;
         char ch2;
 
-        X& operator=(const X& a);
+        X& operator =(const X& a);
         X(const X&);
     };
 
     X waste(const char* p)
     {
         if (!p) throw Nullptr_error{};
-        int n = strlen(p);
-        auto buf = new char[n];
+        int n{ strlen(p) };
+        auto buf{ new char[n] };
         if (!buf) throw Allocation_error{};
-        for (int i = 0; i < n; ++i) buf[i] = p[i];
+        for (int i{ 0 }; i < n; ++i) buf[i] = p[i];
         // ... manipulate buffer ...
         X x;
         x.ch = 'a';
         x.s = string(n);    // give x.s space for *p
-        for (gsl::index i = 0; i < x.s.size(); ++i) x.s[i] = buf[i];  // copy buf into x.s
+        for (gsl::index i{ 0 }; i < x.s.size(); ++i) x.s[i] = buf[i];  // copy buf into x.s
         delete[] buf;
         return x;
     }
 
     void driver()
     {
-        X x = waste("Typical argument");
+        X x{ waste("Typical argument") };
         // ...
     }
 
@@ -1059,7 +1060,7 @@ There are several more performance bugs and gratuitous complication.
 
     void lower(zstring s)
     {
-        for (int i = 0; i < strlen(s); ++i) s[i] = tolower(s[i]);
+        for (int i{ 0 }; i < strlen(s); ++i) s[i] = tolower(s[i]);
     }
 
 This is actually an example from production code.
@@ -1100,9 +1101,9 @@ Messy, low-level code breeds more such code.
 
 ##### Example
 
-    int sz = 100;
-    int* p = (int*) malloc(sizeof(int) * sz);
-    int count = 0;
+    int sz{ 100 };
+    int* p{ (int*) malloc(sizeof(int) * sz) };
+    int count{ 0 };
     // ...
     for (;;) {
         // ... read an int into x, exit loop if end of file is reached ...
@@ -1327,7 +1328,7 @@ The rule against global variables applies to namespace scope variables as well.
 **Alternative**: If you use global (more generally namespace scope) data to avoid copying, consider passing the data as an object by reference to `const`.
 Another solution is to define the data as the state of some object and the operations as member functions.
 
-**Warning**: Beware of data races: If one thread can access non-local data (or data passed by reference) while another thread executes the callee, we can have a data race.
+**Warning**: Beware of data races: If one thread can access nonlocal data (or data passed by reference) while another thread executes the callee, we can have a data race.
 Every pointer or reference to mutable data is a potential data race.
 
 Using global pointers or references to access and change non-const, and otherwise non-global,
@@ -1543,9 +1544,9 @@ Consider:
 
     double sqrt(double x);
 
-Here `x` must be non-negative. The type system cannot (easily and naturally) express that, so we must use other means. For example:
+Here `x` must be nonnegative. The type system cannot (easily and naturally) express that, so we must use other means. For example:
 
-    double sqrt(double x); // x must be non-negative
+    double sqrt(double x); // x must be nonnegative
 
 Some preconditions can be expressed as assertions. For example:
 
@@ -1604,7 +1605,7 @@ Once language support becomes available (e.g., see the [contract proposal](http:
 
 ##### Note
 
-No, using `unsigned` is not a good way to sidestep the problem of [ensuring that a value is non-negative](#Res-non-negative).
+No, using `unsigned` is not a good way to sidestep the problem of [ensuring that a value is nonnegative](#Res-nonnegative).
 
 ##### Enforcement
 
@@ -2372,7 +2373,7 @@ Other function rules:
 * [F.50: Use a lambda when a function won't do (to capture local variables, or to write a local function)](#Rf-capture-vs-overload)
 * [F.51: Where there is a choice, prefer default arguments over overloading](#Rf-default-args)
 * [F.52: Prefer capturing by reference in lambdas that will be used locally, including passed to algorithms](#Rf-reference-capture)
-* [F.53: Avoid capturing by reference in lambdas that will be used non-locally, including returned, stored on the heap, or passed to another thread](#Rf-value-capture)
+* [F.53: Avoid capturing by reference in lambdas that will be used nonlocally, including returned, stored on the heap, or passed to another thread](#Rf-value-capture)
 * [F.54: If you capture `this`, capture all variables explicitly (no default capture)](#Rf-this-capture)
 * [F.55: Don't use `va_arg` arguments](#F-varargs)
 
@@ -3873,7 +3874,7 @@ This is a simple three-stage parallel pipeline. Each `stage` object encapsulates
 
 Flag a lambda that captures by reference, but is used other than locally within the function scope or passed to a function by reference. (Note: This rule is an approximation, but does flag passing by pointer as those are more likely to be stored by the callee, writing to a heap location accessed via a parameter, returning the lambda, etc. The Lifetime rules will also provide general rules that flag escaping pointers and references including via lambdas.)
 
-### <a name="Rf-value-capture"></a>F.53: Avoid capturing by reference in lambdas that will be used non-locally, including returned, stored on the heap, or passed to another thread
+### <a name="Rf-value-capture"></a>F.53: Avoid capturing by reference in lambdas that will be used nonlocally, including returned, stored on the heap, or passed to another thread
 
 ##### Reason
 
@@ -4493,7 +4494,7 @@ Destructor rules:
 * [C.31: All resources acquired by a class must be released by the class's destructor](#Rc-dtor-release)
 * [C.32: If a class has a raw pointer (`T*`) or reference (`T&`), consider whether it might be owning](#Rc-dtor-ptr)
 * [C.33: If a class has an owning pointer member, define or `=delete` a destructor](#Rc-dtor-ptr2)
-* [C.35: A base class destructor should be either public and virtual, or protected and non-virtual](#Rc-dtor-virtual)
+* [C.35: A base class destructor should be either public and virtual, or protected and nonvirtual](#Rc-dtor-virtual)
 * [C.36: A destructor may not fail](#Rc-dtor-fail)
 * [C.37: Make destructors `noexcept`](#Rc-dtor-noexcept)
 
@@ -4701,7 +4702,7 @@ Users will be surprised if copy/move construction and copy/move assignment do lo
         };
         shared_ptr<Impl> p;
     public:
-        Silly(const Silly& a) : p(make_shared<Impl>()) { *p = *a.p; }   // deep copy
+        Silly(const Silly& a) : p{a.p} { *p = *a.p; }   // deep copy
         Silly& operator=(const Silly& a) { p = a.p; }   // shallow copy
         // ...
     };
@@ -4934,7 +4935,7 @@ That would sometimes require non-trivial code changes and may affect ABIs.
 * A class with an `owner<T>` should define its default operations.
 
 
-### <a name="Rc-dtor-virtual"></a>C.35: A base class destructor should be either public and virtual, or protected and non-virtual
+### <a name="Rc-dtor-virtual"></a>C.35: A base class destructor should be either public and virtual, or protected and nonvirtual
 
 ##### Reason
 
@@ -4949,7 +4950,7 @@ See [this in the Discussion section](#Sd-dtor).
 
 ##### Example, bad
 
-    struct Base {  // BAD: implicitly has a public non-virtual destructor
+    struct Base {  // BAD: implicitly has a public nonvirtual destructor
         virtual void f();
     };
 
@@ -4972,7 +4973,7 @@ If the interface allows destroying, it should be safe to do so.
 
 ##### Note
 
-A destructor must be non-private or it will prevent using the type:
+A destructor must be nonprivate or it will prevent using the type:
 
     class X {
         ~X();   // private destructor
@@ -4992,7 +4993,7 @@ We can imagine one case where you could want a protected virtual destructor: Whe
 
 ##### Enforcement
 
-* A class with any virtual functions should have a destructor that is either public and virtual or else protected and non-virtual.
+* A class with any virtual functions should have a destructor that is either public and virtual or else protected and nonvirtual.
 
 ### <a name="Rc-dtor-fail"></a>C.36: A destructor may not fail
 
@@ -6389,7 +6390,7 @@ A `swap` can be handy for implementing a number of idioms, from smoothly moving 
         int m2;
     };
 
-Providing a non-member `swap` function in the same namespace as your type for callers' convenience.
+Providing a nonmember `swap` function in the same namespace as your type for callers' convenience.
 
     void swap(Foo& a, Foo& b)
     {
@@ -6788,7 +6789,7 @@ Summary:
 
 * [F.50: Use a lambda when a function won't do (to capture local variables, or to write a local function)](#Rf-capture-vs-overload)
 * [F.52: Prefer capturing by reference in lambdas that will be used locally, including passed to algorithms](#Rf-reference-capture)
-* [F.53: Avoid capturing by reference in lambdas that will be used non-locally, including returned, stored on the heap, or passed to another thread](#Rf-value-capture)
+* [F.53: Avoid capturing by reference in lambdas that will be used nonlocally, including returned, stored on the heap, or passed to another thread](#Rf-value-capture)
 * [ES.28: Use lambdas for complex initialization, especially of `const` variables](#Res-lambda-init)
 
 ## <a name="SS-hier"></a>C.hier: Class hierarchies (OOP)
@@ -6896,7 +6897,7 @@ not using this (over)general interface in favor of a particular interface found 
 ##### Enforcement
 
 * Look for classes with lots of members that do nothing but throw.
-* Flag every use of a non-public base class `B` where the derived class `D` does not override a virtual function or access a protected member in `B`, and `B` is not one of the following: empty, a template parameter or parameter pack of `D`, a class template specialized with `D`.
+* Flag every use of a nonpublic base class `B` where the derived class `D` does not override a virtual function or access a protected member in `B`, and `B` is not one of the following: empty, a template parameter or parameter pack of `D`, a class template specialized with `D`.
 
 ### <a name="Rh-abstract"></a>C.121: If a base class is used as an interface, make it a pure abstract class
 
@@ -7002,13 +7003,13 @@ Flag abstract classes with constructors.
 
 ##### Reason
 
-A class with a virtual function is usually (and in general) used via a pointer to base. Usually, the last user has to call delete on a pointer to base, often via a smart pointer to base, so the destructor should be public and virtual. Less commonly, if deletion through a pointer to base is not intended to be supported, the destructor should be protected and non-virtual; see [C.35](#Rc-dtor-virtual).
+A class with a virtual function is usually (and in general) used via a pointer to base. Usually, the last user has to call delete on a pointer to base, often via a smart pointer to base, so the destructor should be public and virtual. Less commonly, if deletion through a pointer to base is not intended to be supported, the destructor should be protected and nonvirtual; see [C.35](#Rc-dtor-virtual).
 
 ##### Example, bad
 
     struct B {
         virtual int f() = 0;
-        // ... no user-written destructor, defaults to public non-virtual ...
+        // ... no user-written destructor, defaults to public nonvirtual ...
     };
 
     // bad: derived from a class without a virtual destructor
@@ -7028,7 +7029,7 @@ There are people who don't follow this rule because they plan to use a class onl
 
 ##### Enforcement
 
-* A class with any virtual functions should have a destructor that is either public and virtual or else protected and non-virtual.
+* A class with any virtual functions should have a destructor that is either public and virtual or else protected and nonvirtual.
 * Flag `delete` of a class with a virtual function but no virtual destructor.
 
 ### <a name="Rh-override"></a>C.128: Virtual functions should specify exactly one of `virtual`, `override`, or `final`
@@ -7075,7 +7076,7 @@ It's simple and clear:
 We want to eliminate two particular classes of errors:
 
 * **implicit virtual**: the programmer intended the function to be implicitly virtual and it is (but readers of the code can't tell); or the programmer intended the function to be implicitly virtual but it isn't (e.g., because of a subtle parameter list mismatch); or the programmer did not intend the function to be virtual but it is (because it happens to have the same signature as a virtual in the base class)
-* **implicit override**: the programmer intended the function to be implicitly an overrider and it is (but readers of the code can't tell); or the programmer intended the function to be implicitly an overrider but it isn't (e.g., because of a subtle parameter list mismatch); or the programmer did not intend the function to be an overrider but it is (because it happens to have the same signature as a virtual in the base class -- note this problem arises whether or not the function is explicitly declared virtual, because the programmer may have intended to create either a new virtual function or a new non-virtual function)
+* **implicit override**: the programmer intended the function to be implicitly an overrider and it is (but readers of the code can't tell); or the programmer intended the function to be implicitly an overrider but it isn't (e.g., because of a subtle parameter list mismatch); or the programmer did not intend the function to be an overrider but it is (because it happens to have the same signature as a virtual in the base class -- note this problem arises whether or not the function is explicitly declared virtual, because the programmer may have intended to create either a new virtual function or a new nonvirtual function)
 
 ##### Enforcement
 
@@ -7634,7 +7635,7 @@ Without a using declaration, member functions in the derived class hide the enti
 
 ##### Note
 
-This issue affects both virtual and non-virtual member functions
+This issue affects both virtual and nonvirtual member functions
 
 For variadic bases, C++17 introduced a variadic form of the using-declaration,
 
@@ -8076,7 +8077,7 @@ You cannot overload function objects.
 Overload rule summary:
 
 * [C.160: Define operators primarily to mimic conventional usage](#Ro-conventional)
-* [C.161: Use non-member functions for symmetric operators](#Ro-symmetric)
+* [C.161: Use nonmember functions for symmetric operators](#Ro-symmetric)
 * [C.162: Overload operations that are roughly equivalent](#Ro-equivalent)
 * [C.163: Overload only for operations that are roughly equivalent](#Ro-equivalent-2)
 * [C.164: Avoid implicit conversion operators](#Ro-conversion)
@@ -8111,19 +8112,19 @@ Here, the conventional semantics is maintained: [Copies compare equal](#SS-copy)
 
 ##### Note
 
-Non-member operators should be either friends or defined in [the same namespace as their operands](#Ro-namespace).
+Nonmember operators should be either friends or defined in [the same namespace as their operands](#Ro-namespace).
 [Binary operators should treat their operands equivalently](#Ro-symmetric).
 
 ##### Enforcement
 
 Possibly impossible.
 
-### <a name="Ro-symmetric"></a>C.161: Use non-member functions for symmetric operators
+### <a name="Ro-symmetric"></a>C.161: Use nonmember functions for symmetric operators
 
 ##### Reason
 
 If you use member functions, you need two.
-Unless you use a non-member function for (say) `==`, `a == b` and `b == a` will be subtly different.
+Unless you use a nonmember function for (say) `==`, `a == b` and `b == a` will be subtly different.
 
 ##### Example
 
@@ -9843,7 +9844,7 @@ The following should not pass code review:
 
     void my_code()
     {
-        // BAD: passing pointer or reference obtained from a non-local smart pointer
+        // BAD: passing pointer or reference obtained from a nonlocal smart pointer
         //      that could be inadvertently reset somewhere inside f or its callees
         f(*g_p);
 
@@ -9867,7 +9868,7 @@ The fix is simple -- take a local copy of the pointer to "keep a ref count" for 
 
 ##### Enforcement
 
-* (Simple) Warn if a pointer or reference obtained from a smart pointer variable (`Unique_pointer` or `Shared_pointer`) that is non-local, or that is local but potentially aliased, is used in a function call. If the smart pointer is a `Shared_pointer` then suggest taking a local copy of the smart pointer and obtain a pointer or reference from that instead.
+* (Simple) Warn if a pointer or reference obtained from a smart pointer variable (`Unique_pointer` or `Shared_pointer`) that is nonlocal, or that is local but potentially aliased, is used in a function call. If the smart pointer is a `Shared_pointer` then suggest taking a local copy of the smart pointer and obtain a pointer or reference from that instead.
 
 # <a name="S-expr"></a>ES: Expressions and statements
 
@@ -9884,7 +9885,7 @@ Declaration rules:
 
 * [ES.5: Keep scopes small](#Res-scope)
 * [ES.6: Declare names in for-statement initializers and conditions to limit scope](#Res-cond)
-* [ES.7: Keep common and local names short, and keep uncommon and non-local names longer](#Res-name-length)
+* [ES.7: Keep common and local names short, and keep uncommon and nonlocal names longer](#Res-name-length)
 * [ES.8: Avoid similar-looking names](#Res-name-similar)
 * [ES.9: Avoid `ALL_CAPS` names](#Res-not-CAPS)
 * [ES.10: Declare one name (only) per declaration](#Res-name-one)
@@ -10136,7 +10137,7 @@ Note: C++17 and C++20 also add `if`, `switch`, and range-`for` initializer state
 
 
 
-### <a name="Res-name-length"></a>ES.7: Keep common and local names short, and keep uncommon and non-local names longer
+### <a name="Res-name-length"></a>ES.7: Keep common and local names short, and keep uncommon and nonlocal names longer
 
 ##### Reason
 
@@ -10945,7 +10946,7 @@ The definition of `a2` is C but not C++ and is considered a security risk
 
 ##### Reason
 
-It nicely encapsulates local initialization, including cleaning up scratch variables needed only for the initialization, without needing to create a needless non-local yet non-reusable function. It also works for variables that should be `const` but only after some initialization work.
+It nicely encapsulates local initialization, including cleaning up scratch variables needed only for the initialization, without needing to create a needless nonlocal yet nonreusable function. It also works for variables that should be `const` but only after some initialization work.
 
 ##### Example, bad
 
@@ -16561,7 +16562,7 @@ Template definition rule summary:
 * [T.65: Use tag dispatch to provide alternative implementations of functions](#Rt-tag-dispatch)
 * [T.67: Use specialization to provide alternative implementations for irregular types](#Rt-specialization2)
 * [T.68: Use `{}` rather than `()` within templates to avoid ambiguities](#Rt-cast)
-* [T.69: Inside a template, don't make an unqualified non-member function call unless you intend it to be a customization point](#Rt-customization)
+* [T.69: Inside a template, don't make an unqualified nonmember function call unless you intend it to be a customization point](#Rt-customization)
 
 Template and hierarchy rule summary:
 
@@ -16595,7 +16596,7 @@ Other template rules summary:
 * [T.140: Name all operations with potential for reuse](#Rt-name)
 * [T.141: Use an unnamed lambda if you need a simple function object in one place only](#Rt-lambda)
 * [T.142: Use template variables to simplify notation](#Rt-var)
-* [T.143: Don't write unintentionally non-generic code](#Rt-non-generic)
+* [T.143: Don't write unintentionally nongeneric code](#Rt-nongeneric)
 * [T.144: Don't specialize function templates](#Rt-specialize-function)
 * [T.150: Check that a class matches a concept using `static_assert`](#Rt-check-class)
 * [T.??: ????](#Rt-???)
@@ -16781,7 +16782,7 @@ Examples include type erasure as with `std::shared_ptr`'s deleter (but [don't ov
 
 ##### Note
 
-In a class template, non-virtual functions are only instantiated if they're used -- but virtual functions are instantiated every time.
+In a class template, nonvirtual functions are only instantiated if they're used -- but virtual functions are instantiated every time.
 This can bloat code size, and may overconstrain a generic type by instantiating functionality that is never needed.
 Avoid this, even though the standard-library facets made this mistake.
 
@@ -17989,7 +17990,7 @@ When `concept`s become widely available such alternatives can be distinguished d
 * flag function-style casts
 
 
-### <a name="Rt-customization"></a>T.69: Inside a template, don't make an unqualified non-member function call unless you intend it to be a customization point
+### <a name="Rt-customization"></a>T.69: Inside a template, don't make an unqualified nonmember function call unless you intend it to be a customization point
 
 ##### Reason
 
@@ -18009,7 +18010,7 @@ There are three major ways to let calling code customize a template.
 
     template<class T>
     void test2(T t)
-        // Call a non-member function without qualification
+        // Call a nonmember function without qualification
     {
         f(t);  // require f(/*T*/) be available in caller's scope or in T's namespace
     }
@@ -18036,7 +18037,7 @@ this can cause problems like [unintentionally invoking unconstrained function te
 
 ##### Enforcement
 
-* In a template, flag an unqualified call to a non-member function that passes a variable of dependent type when there is a non-member function of the same name in the template's namespace.
+* In a template, flag an unqualified call to a nonmember function that passes a variable of dependent type when there is a nonmember function of the same name in the template's namespace.
 
 
 ## <a name="SS-temp-hier"></a>T.temp-hier: Template and hierarchy rules:
@@ -18529,7 +18530,7 @@ Improved readability.
 
 ???
 
-### <a name="Rt-non-generic"></a>T.143: Don't write unintentionally non-generic code
+### <a name="Rt-nongeneric"></a>T.143: Don't write unintentionally nongeneric code
 
 ##### Reason
 
@@ -18743,11 +18744,10 @@ Source file rule summary:
 * [SF.9: Avoid cyclic dependencies among source files](#Rs-cycles)
 * [SF.10: Avoid dependencies on implicitly `#include`d names](#Rs-implicit)
 * [SF.11: Header files should be self-contained](#Rs-contained)
-* [SF.12: Prefer the angle bracket form of `#include` where you can and the quoted form everywhere else](#Rs-incform)
 
 * [SF.20: Use `namespace`s to express logical structure](#Rs-namespace)
 * [SF.21: Don't use an unnamed (anonymous) namespace in a header](#Rs-unnamed)
-* [SF.22: Use an unnamed (anonymous) namespace for all internal/non-exported entities](#Rs-unnamed2)
+* [SF.22: Use an unnamed (anonymous) namespace for all internal/nonexported entities](#Rs-unnamed2)
 
 ### <a name="Rs-file-suffix"></a>SF.1: Use a `.cpp` suffix for code files and `.h` for interface files if your project doesn't already follow another convention
 
@@ -19182,33 +19182,6 @@ A header should include all its dependencies. Be careful about using relative pa
 
 A test should verify that the header file itself compiles or that a cpp file which only includes the header file compiles.
 
-### <a name="Rs-incform"></a>SF.12: Prefer the angle bracket form of `#include` where you can and the quoted form everywhere else
-
-##### Reason
-
-The [standard](http://eel.is/c++draft/cpp.include) provides flexibility for compilers to implement
-the two forms of `#include` selected using the angle (`<>`) or quoted (`""`) syntax. Vendors take
-advantage of this and use different search algorithms and methods for specifying the include path.
-
-Nevertheless, the guidance is to use the angle form when possible. This supports the fact that the
-standard library headers must be included this way, is more likely to create portable code, and enables
-the quoted form for other uses. For example being clear about the locality of the header relative
-to files that includes it or in scenarios where the different search algorithm is required.
-
-##### Example
-
-    #include <string>       // From the standard library, required form
-    #include "helpers.h"    // A project specific file, use "" form
-
-##### Note
-Failing to follow this results in difficult to diagnose errors due to picking up the wrong file by incorrectly specifying the scope when it is included.
-
-Library creators should put their headers in a folder and have clients include those files using the relative path `#include <some_library/common.h>`
-
-##### Enforcement
-
-A test should identify headers referenced via `""` could be referenced with `<>`.
-
 ### <a name="Rs-namespace"></a>SF.20: Use `namespace`s to express logical structure
 
 ##### Reason
@@ -19237,7 +19210,7 @@ It is almost always a bug to mention an unnamed namespace in a header file.
 
 * Flag any use of an anonymous namespace in a header file.
 
-### <a name="Rs-unnamed2"></a>SF.22: Use an unnamed (anonymous) namespace for all internal/non-exported entities
+### <a name="Rs-unnamed2"></a>SF.22: Use an unnamed (anonymous) namespace for all internal/nonexported entities
 
 ##### Reason
 
@@ -20519,8 +20492,8 @@ A textbook for beginners and relative novices.
 
 ## <a name="SS-vid"></a>RS.video: Videos about "modern C++"
 
-* Bjarne Stroustrup: [C++11 Style](http://channel9.msdn.com/Events/GoingNative/GoingNative-2012/Keynote-Bjarne-Stroustrup-Cpp11-Style). 2012.
-* Bjarne Stroustrup: [The Essence of C++: With Examples in C++84, C++98, C++11, and C++14](http://channel9.msdn.com/Events/GoingNative/2013/Opening-Keynote-Bjarne-Stroustrup). 2013
+* Bjarne Stroustrup: [C++11 Style](http://channel9.msdn.com/Events/GoingNative/GoingNative-2012/Keynote-Bjarne-Stroustrup-Cpp11-Style). 2012.
+* Bjarne Stroustrup: [The Essence of C++: With Examples in C++84, C++98, C++11, and C++14](http://channel9.msdn.com/Events/GoingNative/2013/Opening-Keynote-Bjarne-Stroustrup). 2013
 * All the talks from [CppCon '14](https://isocpp.org/blog/2014/11/cppcon-videos-c9)
 * Bjarne Stroustrup: [The essence of C++](https://www.youtube.com/watch?v=86xWVb4XIyE) at the University of Edinburgh. 2014.
 * Bjarne Stroustrup: [The Evolution of C++ Past, Present and Future](https://www.youtube.com/watch?v=_wzc7a3McOs). CppCon 2016 keynote.
@@ -21777,9 +21750,9 @@ In summary, no post-construction technique is perfect. The worst techniques dodg
 
 **References**: [\[Alexandrescu01\]](#Alexandrescu01) §3, [\[Boost\]](#Boost), [\[Dewhurst03\]](#Dewhurst03) §75, [\[Meyers97\]](#Meyers97) §46, [\[Stroustrup00\]](#Stroustrup00) §15.4.3, [\[Taligent94\]](#Taligent94)
 
-### <a name="Sd-dtor"></a>Discussion: Make base class destructors public and virtual, or protected and non-virtual
+### <a name="Sd-dtor"></a>Discussion: Make base class destructors public and virtual, or protected and nonvirtual
 
-Should destruction behave virtually? That is, should destruction through a pointer to a `base` class be allowed? If yes, then `base`'s destructor must be public in order to be callable, and virtual otherwise calling it results in undefined behavior. Otherwise, it should be protected so that only derived classes can invoke it in their own destructors, and non-virtual since it doesn't need to behave virtually.
+Should destruction behave virtually? That is, should destruction through a pointer to a `base` class be allowed? If yes, then `base`'s destructor must be public in order to be callable, and virtual otherwise calling it results in undefined behavior. Otherwise, it should be protected so that only derived classes can invoke it in their own destructors, and nonvirtual since it doesn't need to behave virtually.
 
 ##### Example
 
@@ -21799,7 +21772,7 @@ The common case for a base class is that it's intended to have publicly derived 
         // ...
     } // ~pb invokes correct destructor only when ~Base is virtual
 
-In rarer cases, such as policy classes, the class is used as a base class for convenience, not for polymorphic behavior. It is recommended to make those destructors protected and non-virtual:
+In rarer cases, such as policy classes, the class is used as a base class for convenience, not for polymorphic behavior. It is recommended to make those destructors protected and nonvirtual:
 
     class My_policy {
     public:
@@ -21816,20 +21789,20 @@ In rarer cases, such as policy classes, the class is used as a base class for co
 
 This simple guideline illustrates a subtle issue and reflects modern uses of inheritance and object-oriented design principles.
 
-For a base class `Base`, calling code might try to destroy derived objects through pointers to `Base`, such as when using a `unique_ptr<Base>`. If `Base`'s destructor is public and non-virtual (the default), it can be accidentally called on a pointer that actually points to a derived object, in which case the behavior of the attempted deletion is undefined. This state of affairs has led older coding standards to impose a blanket requirement that all base class destructors must be virtual. This is overkill (even if it is the common case); instead, the rule should be to make base class destructors virtual if and only if they are public.
+For a base class `Base`, calling code might try to destroy derived objects through pointers to `Base`, such as when using a `unique_ptr<Base>`. If `Base`'s destructor is public and nonvirtual (the default), it can be accidentally called on a pointer that actually points to a derived object, in which case the behavior of the attempted deletion is undefined. This state of affairs has led older coding standards to impose a blanket requirement that all base class destructors must be virtual. This is overkill (even if it is the common case); instead, the rule should be to make base class destructors virtual if and only if they are public.
 
 To write a base class is to define an abstraction (see Items 35 through 37). Recall that for each member function participating in that abstraction, you need to decide:
 
 * Whether it should behave virtually or not.
 * Whether it should be publicly available to all callers using a pointer to `Base` or else be a hidden internal implementation detail.
 
-As described in Item 39, for a normal member function, the choice is between allowing it to be called via a pointer to `Base` non-virtually (but possibly with virtual behavior if it invokes virtual functions, such as in the NVI or Template Method patterns), virtually, or not at all. The NVI pattern is a technique to avoid public virtual functions.
+As described in Item 39, for a normal member function, the choice is between allowing it to be called via a pointer to `Base` nonvirtually (but possibly with virtual behavior if it invokes virtual functions, such as in the NVI or Template Method patterns), virtually, or not at all. The NVI pattern is a technique to avoid public virtual functions.
 
-Destruction can be viewed as just another operation, albeit with special semantics that make non-virtual calls dangerous or wrong. For a base class destructor, therefore, the choice is between allowing it to be called via a pointer to `Base` virtually or not at all; "non-virtually" is not an option. Hence, a base class destructor is virtual if it can be called (i.e., is public), and non-virtual otherwise.
+Destruction can be viewed as just another operation, albeit with special semantics that make nonvirtual calls dangerous or wrong. For a base class destructor, therefore, the choice is between allowing it to be called via a pointer to `Base` virtually or not at all; "nonvirtually" is not an option. Hence, a base class destructor is virtual if it can be called (i.e., is public), and nonvirtual otherwise.
 
 Note that the NVI pattern cannot be applied to the destructor because constructors and destructors cannot make deep virtual calls. (See Items 39 and 55.)
 
-Corollary: When writing a base class, always write a destructor explicitly, because the implicitly generated one is public and non-virtual. You can always `=default` the implementation if the default body is fine and you're just writing the function to give it the proper visibility and virtuality.
+Corollary: When writing a base class, always write a destructor explicitly, because the implicitly generated one is public and nonvirtual. You can always `=default` the implementation if the default body is fine and you're just writing the function to give it the proper visibility and virtuality.
 
 ##### Exception
 
@@ -21842,9 +21815,9 @@ Consider also this rare case:
 
 Then, even though the destructor has to be public, there can be great pressure to not make it virtual because as the first virtual function it would incur all the run-time type overhead when the added functionality should never be needed.
 
-In this rare case, you could make the destructor public and non-virtual but clearly document that further-derived objects must not be used polymorphically as `B`'s. This is what was done with `std::unary_function`.
+In this rare case, you could make the destructor public and nonvirtual but clearly document that further-derived objects must not be used polymorphically as `B`'s. This is what was done with `std::unary_function`.
 
-In general, however, avoid concrete base classes (see Item 35). For example, `unary_function` is a bundle-of-typedefs that was never intended to be instantiated standalone. It really makes no sense to give it a public destructor; a better design would be to follow this Item's advice and give it a protected non-virtual destructor.
+In general, however, avoid concrete base classes (see Item 35). For example, `unary_function` is a bundle-of-typedefs that was never intended to be instantiated standalone. It really makes no sense to give it a public destructor; a better design would be to follow this Item's advice and give it a protected nonvirtual destructor.
 
 **References**: [\[C++CS\]](#CplusplusCS) Item 50, [\[Cargill92\]](#Cargill92) pp. 77-79, 207, [\[Cline99\]](#Cline99) §21.06, 21.12-13, [\[Henricson97\]](#Henricson97) pp. 110-114, [\[Koenig97\]](#Koenig97) Chapters 4, 11, [\[Meyers97\]](#Meyers97) §14, [\[Stroustrup00\]](#Stroustrup00) §12.4.2, [\[Sutter02\]](#Sutter02) §27, [\[Sutter04\]](#Sutter04) §18
 
@@ -22022,7 +21995,7 @@ In many cases, holding properly encapsulated resources using RAII "owning" objec
 
 Prefer compiler-generated (including `=default`) special members; only these can be classified as "trivial", and at least one major standard library vendor heavily optimizes for classes having trivial special members. This is likely to become common practice.
 
-**Exceptions**: When any of the special functions are declared only to make them non-public or virtual, but without special semantics, it doesn't imply that the others are needed.
+**Exceptions**: When any of the special functions are declared only to make them nonpublic or virtual, but without special semantics, it doesn't imply that the others are needed.
 In rare cases, classes that have members of strange types (such as reference members) are an exception because they have peculiar copy semantics.
 In a class holding a reference, you likely need to write the copy constructor and the assignment operator, but the default destructor already does the right thing. (Note that using a reference member is almost always wrong.)
 


### PR DESCRIPTION
I noticed much of the example code does not (yet) follow rule [ES.23](https://github.com/Modanung/CppCoreGuidelines/blob/master/CppCoreGuidelines.md#Res-list). Me and some other programmers seem in agreement that non-empty `{}` with added spaces are more readable than without, and on par with - if not clearer than - using ` = `.
So `int x{ 1 };` and not `int x{1};` instead of `int x = 1;`.

Also, to alleviate searching for blocks of code I figured grave accents would be more convenient than tabs. Before applying this logic to the entire document I would like some feedback as to whether these changes are welcomed in its current form.