### PR TITLE
SF.12: Prefer the quoted form of `#include` for files relative to the…

### DIFF
--- a/CppCoreGuidelines.md
+++ b/CppCoreGuidelines.md
@@ -19190,7 +19190,7 @@ The [standard](http://eel.is/c++draft/cpp.include) provides flexibility for comp
 the two forms of `#include` selected using the angle (`<>`) or quoted (`""`) syntax. Vendors take
 advantage of this and use different search algorithms and methods for specifying the include path.
 
-Nevertheless, the guidance is to use the quoted form for including files that exist at a relative path to the file containing the '#include statement' and to use the angle bracket form everywhere else, where possible. This encourages being clear about the locality of the header relative to files that include it, or scenarios where the different search algorithm is required. For example, it makes it easy to understand at a glance whether a header is being included from a local relative file versus a standard library header or an external header from another project.
+Nevertheless, the guidance is to use the quoted form for including files that exist at a relative path to the file containing the `#include` statement and to use the angle bracket form everywhere else, where possible. This encourages being clear about the locality of the header relative to files that include it, or scenarios where the different search algorithm is required. For example, it makes it easy to understand at a glance whether a header is being included from a local relative file versus a standard library header or an external header from another project.
 
 ##### Example
     // foo.cpp:
@@ -19200,7 +19200,7 @@ Nevertheless, the guidance is to use the quoted form for including files that ex
     #include "foo_utils/utils.h"     // A file locally relative to foo.cpp, use "" form
 
 ##### Note
-Failing to follow this results in difficult to diagnose errors due to picking up the wrong file by incorrectly specifying the scope when it is included. For example, in a typical case where the '#include ""' search algorithm may search for a file existing at a local relative path first, then using this form to refer to a file that is not locally relative could mean that if a file ever comes into existence at the local relative path (e.g. the including file is moved to a new location), it will now be found ahead of the previous include file and the set of includes will have been changed in an unexpected way.
+Failing to follow this results in difficult to diagnose errors due to picking up the wrong file by incorrectly specifying the scope when it is included. For example, in a typical case where the `#include ""` search algorithm may search for a file existing at a local relative path first, then using this form to refer to a file that is not locally relative could mean that if a file ever comes into existence at the local relative path (e.g. the including file is moved to a new location), it will now be found ahead of the previous include file and the set of includes will have been changed in an unexpected way.
 
 Library creators should put their headers in a folder and have clients include those files using the relative path `#include <some_library/common.h>`
 

--- a/CppCoreGuidelines.md
+++ b/CppCoreGuidelines.md
@@ -19190,17 +19190,17 @@ The [standard](http://eel.is/c++draft/cpp.include) provides flexibility for comp
 the two forms of `#include` selected using the angle (`<>`) or quoted (`""`) syntax. Vendors take
 advantage of this and use different search algorithms and methods for specifying the include path.
 
-Nevertheless, the guidance is to use quoted form for including files that exist at a relative path to the file containing the #include statement and to use the angle bracket form everywhere else where possible. This supports being clear about the locality of the header relative to files that includes it or in scenarios where the different search algorithm is required. For example, it makes it easy to determine at a glance whether a header is being included from a local relative file versus a standard library header or an external header from another project.
+Nevertheless, the guidance is to use the quoted form for including files that exist at a relative path to the file containing the '#include statement' and to use the angle bracket form everywhere else, where possible. This encourages being clear about the locality of the header relative to files that include it, or scenarios where the different search algorithm is required. For example, it makes it easy to understand at a glance whether a header is being included from a local relative file versus a standard library header or an external header from another project.
 
 ##### Example
-foo.cpp:
-    #include <string>       // From the standard library, required form
-    #include <some_library/common.h>    //A non-local include file from an external library, use the <> form
-    #include "foo.h"    // A local file relative to foo.cpp, use "" form
-    #include "utils/foo_utils.h"    // A local file relative to foo.cpp, use "" form
+    // foo.cpp:
+    #include <string>                // From the standard library, requires the <> form
+    #include <some_library/common.h> // A file that is not locally relative, included from an external project; use the <> form
+    #include "foo.h"                 // A file locally relative to foo.cpp, use the "" form
+    #include "foo_utils/utils.h"     // A file locally relative to foo.cpp, use "" form
 
 ##### Note
-Failing to follow this results in difficult to diagnose errors due to picking up the wrong file by incorrectly specifying the scope when it is included.
+Failing to follow this results in difficult to diagnose errors due to picking up the wrong file by incorrectly specifying the scope when it is included. For example, in a typical case where the '#include ""' search algorithm may search for a file existing at a local relative path first, then using this form to refer to a file that is not locally relative could mean that if a file ever comes into existence at the local relative path (e.g. the including file is moved to a new location), it will now be found ahead of the previous include file and the set of includes will have been changed in an unexpected way.
 
 Library creators should put their headers in a folder and have clients include those files using the relative path `#include <some_library/common.h>`
 

--- a/CppCoreGuidelines.md
+++ b/CppCoreGuidelines.md
@@ -19189,12 +19189,13 @@ The [standard](http://eel.is/c++draft/cpp.include) provides flexibility for comp
 the two forms of `#include` selected using the angle (`<>`) or quoted (`""`) syntax. Vendors take
 advantage of this and use different search algorithms and methods for specifying the include path.
 
-Nevertheless, the guidance is to use the quoted form for including files that exist at a relative path to the file containing the `#include` statement and to use the angle bracket form everywhere else, where possible. This encourages being clear about the locality of the header relative to files that include it, or scenarios where the different search algorithm is required. For example, it makes it easy to understand at a glance whether a header is being included from a local relative file versus a standard library header or an external header from another project.
+Nevertheless, the guidance is to use the quoted form for including files that exist at a relative path to the file containing the `#include` statement and to use the angle bracket form everywhere else, where possible. This encourages being clear about the locality of the header relative to files that include it, or scenarios where the different search algorithm is required. It makes it easy to understand at a glance whether a header is being included from a local relative file versus a standard library header or a header from the alternate search path (e.g. a header from another project or a common set of includes).
 
 ##### Example
+
     // foo.cpp:
     #include <string>                // From the standard library, requires the <> form
-    #include <some_library/common.h> // A file that is not locally relative, included from an external project; use the <> form
+    #include <some_library/common.h> // A file that is not locally relative, included from another project; use the <> form
     #include "foo.h"                 // A file locally relative to foo.cpp, use the "" form
     #include "foo_utils/utils.h"     // A file locally relative to foo.cpp, use "" form
 

--- a/CppCoreGuidelines.md
+++ b/CppCoreGuidelines.md
@@ -19189,13 +19189,13 @@ The [standard](http://eel.is/c++draft/cpp.include) provides flexibility for comp
 the two forms of `#include` selected using the angle (`<>`) or quoted (`""`) syntax. Vendors take
 advantage of this and use different search algorithms and methods for specifying the include path.
 
-Nevertheless, the guidance is to use the quoted form for including files that exist at a relative path to the file containing the `#include` statement and to use the angle bracket form everywhere else, where possible. This encourages being clear about the locality of the header relative to files that include it, or scenarios where the different search algorithm is required. It makes it easy to understand at a glance whether a header is being included from a local relative file versus a standard library header or a header from the alternate search path (e.g. a header from another project or a common set of includes).
+Nevertheless, the guidance is to use the quoted form for including files that exist at a relative path to the file containing the `#include` statement and to use the angle bracket form everywhere else, where possible. This encourages being clear about the locality of the header relative to files that include it, or scenarios where the different search algorithm is required. It makes it easy to understand at a glance whether a header is being included from a local relative file versus a standard library header or a header from the alternate search path (e.g. a header from another library or a common set of includes).
 
 ##### Example
 
     // foo.cpp:
     #include <string>                // From the standard library, requires the <> form
-    #include <some_library/common.h> // A file that is not locally relative, included from another project; use the <> form
+    #include <some_library/common.h> // A file that is not locally relative, included from another library; use the <> form
     #include "foo.h"                 // A file locally relative to foo.cpp, use the "" form
     #include "foo_utils/utils.h"     // A file locally relative to foo.cpp, use the "" form
 

--- a/CppCoreGuidelines.md
+++ b/CppCoreGuidelines.md
@@ -18743,7 +18743,7 @@ Source file rule summary:
 * [SF.9: Avoid cyclic dependencies among source files](#Rs-cycles)
 * [SF.10: Avoid dependencies on implicitly `#include`d names](#Rs-implicit)
 * [SF.11: Header files should be self-contained](#Rs-contained)
-* [SF.12: Prefer the angle bracket form of `#include` where you can and the quoted form everywhere else](#Rs-incform)
+* [SF.12: Prefer the quoted form of `#include` for files relative to the including file and the angle bracket form everywhere else](#Rs-incform)
 
 * [SF.20: Use `namespace`s to express logical structure](#Rs-namespace)
 * [SF.21: Don't use an unnamed (anonymous) namespace in a header](#Rs-unnamed)
@@ -19182,7 +19182,7 @@ A header should include all its dependencies. Be careful about using relative pa
 
 A test should verify that the header file itself compiles or that a cpp file which only includes the header file compiles.
 
-### <a name="Rs-incform"></a>SF.12: Prefer the angle bracket form of `#include` where you can and the quoted form everywhere else
+### <a name="Rs-incform"></a>SF.12: Prefer the quoted form of `#include` for files relative to the including file and the angle bracket form everywhere else
 
 ##### Reason
 
@@ -19190,15 +19190,14 @@ The [standard](http://eel.is/c++draft/cpp.include) provides flexibility for comp
 the two forms of `#include` selected using the angle (`<>`) or quoted (`""`) syntax. Vendors take
 advantage of this and use different search algorithms and methods for specifying the include path.
 
-Nevertheless, the guidance is to use the angle form when possible. This supports the fact that the
-standard library headers must be included this way, is more likely to create portable code, and enables
-the quoted form for other uses. For example being clear about the locality of the header relative
-to files that includes it or in scenarios where the different search algorithm is required.
+Nevertheless, the guidance is to use quoted form for including files that exist at a relative path to the file containing the #include statement and to use the angle bracket form everywhere else where possible. This supports being clear about the locality of the header relative to files that includes it or in scenarios where the different search algorithm is required. For example, it makes it easy to determine at a glance whether a header is being included from a local relative file versus a standard library header or an external header from another project.
 
 ##### Example
-
+foo.cpp:
     #include <string>       // From the standard library, required form
-    #include "helpers.h"    // A project specific file, use "" form
+    #include <some_library/common.h>    //A non-local include file from an external library, use the <> form
+    #include "foo.h"    // A local file relative to foo.cpp, use "" form
+    #include "utils/foo_utils.h"    // A local file relative to foo.cpp, use "" form
 
 ##### Note
 Failing to follow this results in difficult to diagnose errors due to picking up the wrong file by incorrectly specifying the scope when it is included.

--- a/CppCoreGuidelines.md
+++ b/CppCoreGuidelines.md
@@ -19197,7 +19197,7 @@ Nevertheless, the guidance is to use the quoted form for including files that ex
     #include <string>                // From the standard library, requires the <> form
     #include <some_library/common.h> // A file that is not locally relative, included from another project; use the <> form
     #include "foo.h"                 // A file locally relative to foo.cpp, use the "" form
-    #include "foo_utils/utils.h"     // A file locally relative to foo.cpp, use "" form
+    #include "foo_utils/utils.h"     // A file locally relative to foo.cpp, use the "" form
 
 ##### Note
 

--- a/CppCoreGuidelines.md
+++ b/CppCoreGuidelines.md
@@ -19189,16 +19189,15 @@ The [standard](http://eel.is/c++draft/cpp.include) provides flexibility for comp
 the two forms of `#include` selected using the angle (`<>`) or quoted (`""`) syntax. Vendors take
 advantage of this and use different search algorithms and methods for specifying the include path.
 
-Nevertheless, the guidance is to use the quoted form for including files that exist at a relative path to the file containing the `#include` statement and to use the angle bracket form everywhere else, where possible. This encourages being clear about the locality of the file relative to files that include it, or scenarios where the different search algorithm is required. It makes it easy to understand at a glance whether a header is being included from a local relative file versus a standard library header or a header from the alternate search path (e.g. a header from another library or a common set of includes). 
-Note that this guidance applies to the including file as it exists in the location where it is typically authored/edited, and not any other location to which it may subsequently be copied or installed or otherwise made available to the implementation.
+Nevertheless, the guidance is to use the quoted form for including files that exist at a relative path to the file containing the `#include` statement (from within the same component or project) and to use the angle bracket form everywhere else, where possible. This encourages being clear about the locality of the file relative to files that include it, or scenarios where the different search algorithm is required. It makes it easy to understand at a glance whether a header is being included from a local relative file versus a standard library header or a header from the alternate search path (e.g. a header from another library or a common set of includes).
 
 ##### Example
 
     // foo.cpp:
     #include <string>                // From the standard library, requires the <> form
     #include <some_library/common.h> // A file that is not locally relative, included from another library; use the <> form
-    #include "foo.h"                 // A file locally relative to foo.cpp, use the "" form
-    #include "foo_utils/utils.h"     // A file locally relative to foo.cpp, use the "" form
+    #include "foo.h"                 // A file locally relative to foo.cpp in the same project, use the "" form
+    #include "foo_utils/utils.h"     // A file locally relative to foo.cpp in the same project, use the "" form
 
 ##### Note
 

--- a/CppCoreGuidelines.md
+++ b/CppCoreGuidelines.md
@@ -19189,7 +19189,8 @@ The [standard](http://eel.is/c++draft/cpp.include) provides flexibility for comp
 the two forms of `#include` selected using the angle (`<>`) or quoted (`""`) syntax. Vendors take
 advantage of this and use different search algorithms and methods for specifying the include path.
 
-Nevertheless, the guidance is to use the quoted form for including files that exist at a relative path to the file containing the `#include` statement and to use the angle bracket form everywhere else, where possible. This encourages being clear about the locality of the header relative to files that include it, or scenarios where the different search algorithm is required. It makes it easy to understand at a glance whether a header is being included from a local relative file versus a standard library header or a header from the alternate search path (e.g. a header from another library or a common set of includes).
+Nevertheless, the guidance is to use the quoted form for including files that exist at a relative path to the file containing the `#include` statement and to use the angle bracket form everywhere else, where possible. This encourages being clear about the locality of the file relative to files that include it, or scenarios where the different search algorithm is required. It makes it easy to understand at a glance whether a header is being included from a local relative file versus a standard library header or a header from the alternate search path (e.g. a header from another library or a common set of includes). 
+Note that this guidance applies to the including file as it exists in the location where it is typically authored/edited, and not any other location to which it may subsequently be copied or installed or otherwise made available to the implementation.
 
 ##### Example
 


### PR DESCRIPTION
… including file

The current guidance on SF.12 can be over-applied and devolves into "always use <>" because all compilers support adding include directories to the <> search. In this case, even the current directory may be added and so it is always possible to use <> for every header. Applying the guidance then devolves into an undesirable state where <> is always used and include"" is never used.

Instead, the proposed guidance leverages and encourages the distinction between <> and "" to create an easy-to-understand rule that the original guidance hints at and that most developers already follow and understand: "" is for local headers and <> is for library and external headers.