### PR TITLE
ES.40: One example not "OK"; wording out of date for C++17

### DIFF
--- a/CppCoreGuidelines.md
+++ b/CppCoreGuidelines.md
@@ -11211,11 +11211,8 @@ Complicated expressions are error-prone.
     // better, but possibly still too complicated
     for (char c1, c2; cin >> c1 >> c2 && c1 == c2;)
 
-    // OK: if i and j are not aliased
-    int x = ++i + ++j;
-
-    // OK: if i != j and i != k
-    v[i] = v[j] + v[k];
+    // bad: multiple side effects, plus undefined behavior if i == j
+    int x = ++a[i] + ++a[j];
 
     // bad: multiple assignments "hidden" in subexpressions
     x = a + (b = f()) + (c = g()) * 7;
@@ -11223,16 +11220,14 @@ Complicated expressions are error-prone.
     // bad: relies on commonly misunderstood precedence rules
     x = a & b + c * d && e ^ f == 7;
 
-    // bad: undefined behavior
-    x = x++ + x++ + ++x;
-
 Some of these expressions are unconditionally bad (e.g., they rely on undefined behavior). Others are simply so complicated and/or unusual that even good programmers could misunderstand them or overlook a problem when in a hurry.
 
 ##### Note
 
-C++17 tightens up the rules for the order of evaluation
-(left-to-right except right-to-left in assignments, and the order of evaluation of function arguments is unspecified; [see ES.43](#Res-order)),
+C++17 tightens up the order-of-evaluation rules for some kinds of expressions
+(left-to-right for postfix and shift expressions, right-to-left for assignments),
 but that doesn't change the fact that complicated expressions are potentially confusing.
+See [ES.43](#Res-order).
 
 ##### Note
 
@@ -11258,7 +11253,7 @@ Tricky. How complicated must an expression be to be considered complicated? Writ
 * side effects: side effects on multiple non-local variables (for some definition of non-local) can be suspect, especially if the side effects are in separate subexpressions
 * writes to aliased variables
 * more than N operators (and what should N be?)
-* reliance of subtle precedence rules
+* reliance on subtle precedence rules
 * uses undefined behavior (can we catch all undefined behavior?)
 * implementation defined behavior?
 * ???


### PR DESCRIPTION
For C++17's guarantees, see
https://stackoverflow.com/questions/38501587/what-are-the-evaluation-order-guarantees-introduced-by-c17

The line of code

    int x = ++i + ++j;

should never ever pass code review. So it's not "OK" and shouldn't
be used as a positive example.

Vice versa, there is literally nothing wrong with

    v[i] = v[j] + v[k];

It does two loads, an add, and a store. Its single side-effect
(on v[i]) is completely unaffected by any aliasing relationships
between i, j, and k. So the comment was misleading. But rather
than mark it "OK", let's just show an unambiguously bad example
created by combining the two examples above.