### PR TITLE
New Rule: Keep Forward Declarations Independent

### DIFF
--- a/CppCoreGuidelines.md
+++ b/CppCoreGuidelines.md
@@ -19258,10 +19258,10 @@ An API class and its members can't live in an unnamed namespace; but any "helper
 ### <a name="Rs-forward"></a>SF.23: Keep forward declarations independent
 
 ##### Reason
-- Reading a forward declaration is easier since all the needed information is on the one line
-- Refactoring is easier because when a class moves namespaces only the lines that forward declare it must be changed. Renaming a namespace is still just a find and replace.
-- Merging is easier because each line is independent
-- Writing is easier because it's easier to decide where to insert (because it doesn't make a difference)
+Reading a forward declaration is easier since all the needed information is on the one line
+Refactoring is easier because when a class moves namespaces only the lines that forward declare it must be changed. Renaming a namespace is still just a find and replace.
+Merging is easier because each line is independent
+Writing is easier because it's easier to decide where to insert (because it doesn't make a difference)
 
 ##### Example
 
@@ -19277,7 +19277,7 @@ Bad
 
 Good
 
-	namespace MyNamespace::InnerNamespace { class C1; }
+    namespace MyNamespace::InnerNamespace { class C1; }
     namespace MyNamespace::InnerNamespace { class C2; }
     namespace MyNamespace { class C3; }
 

--- a/CppCoreGuidelines.md
+++ b/CppCoreGuidelines.md
@@ -19268,11 +19268,11 @@ An API class and its members can't live in an unnamed namespace; but any "helper
 Bad
 
     namespace MyNamespace {
-        namespace InnerNamespace {
-            class C1;
-            class C2;
-        }
-        class C3;
+    namespace InnerNamespace {
+    class C1;
+    class C2;
+    }
+    class C3;
     }
 
 Good

--- a/CppCoreGuidelines.md
+++ b/CppCoreGuidelines.md
@@ -19255,7 +19255,7 @@ An API class and its members can't live in an unnamed namespace; but any "helper
 
 * ???
 
-### <a name="#Rs-forward"></a>SF.23: Keep forward declarations independent
+### <a name="Rs-forward"></a>SF.23: Keep forward declarations independent
 
 ##### Reason
 - Reading a forward declaration is easier since all the needed information is on the one line

--- a/CppCoreGuidelines.md
+++ b/CppCoreGuidelines.md
@@ -19258,6 +19258,7 @@ An API class and its members can't live in an unnamed namespace; but any "helper
 ### <a name="Rs-forward"></a>SF.23: Keep forward declarations independent
 
 ##### Reason
+
 Reading a forward declaration is easier since all the needed information is on the one line
 Refactoring is easier because when a class moves namespaces only the lines that forward declare it must be changed. Renaming a namespace is still just a find and replace.
 Merging is easier because each line is independent

--- a/CppCoreGuidelines.md
+++ b/CppCoreGuidelines.md
@@ -19267,10 +19267,8 @@ An API class and its members can't live in an unnamed namespace; but any "helper
 
 Bad
 
-    namespace MyNamespace
-    {
-        namespace InnerNamespace
-        {
+    namespace MyNamespace {
+        namespace InnerNamespace {
             class C1;
             class C2;
         }

--- a/CppCoreGuidelines.md
+++ b/CppCoreGuidelines.md
@@ -19260,7 +19260,7 @@ An API class and its members can't live in an unnamed namespace; but any "helper
 ##### Reason
 
 Reading a forward declaration is easier since all the needed information is on the one line.
-Refactoring is easier because when a class moves namespaces only the lines that forward declare it must be changed. Renaming a namespace is still just a find and replace.
+Refactoring is easier because when a class moves namespaces only the lines that forward-declare it must be changed. Renaming a namespace is still just a find and replace.
 Merging is easier because each line is independent.
 Writing is easier because it's easier to decide where to insert (because it doesn't make a difference).
 

--- a/CppCoreGuidelines.md
+++ b/CppCoreGuidelines.md
@@ -19259,10 +19259,10 @@ An API class and its members can't live in an unnamed namespace; but any "helper
 
 ##### Reason
 
-Reading a forward declaration is easier since all the needed information is on the one line
+Reading a forward declaration is easier since all the needed information is on the one line.
 Refactoring is easier because when a class moves namespaces only the lines that forward declare it must be changed. Renaming a namespace is still just a find and replace.
-Merging is easier because each line is independent
-Writing is easier because it's easier to decide where to insert (because it doesn't make a difference)
+Merging is easier because each line is independent.
+Writing is easier because it's easier to decide where to insert (because it doesn't make a difference).
 
 ##### Example
 
@@ -19285,6 +19285,10 @@ Good
 ##### Note
 
 This assumes that namespace names are sufficiently short and nesting is sufficiently shallow to avoid violating any line length limits. If this is not the case, it may indicate namespace names are too long or deeply nested.
+
+##### Note
+
+This is applicable from C++17 onward. Prior to C++17 this namespace nesting syntax was not permitted in declarations.
 
 ##### Enforcement
 

--- a/CppCoreGuidelines.md
+++ b/CppCoreGuidelines.md
@@ -18747,6 +18747,7 @@ Source file rule summary:
 * [SF.20: Use `namespace`s to express logical structure](#Rs-namespace)
 * [SF.21: Don't use an unnamed (anonymous) namespace in a header](#Rs-unnamed)
 * [SF.22: Use an unnamed (anonymous) namespace for all internal/non-exported entities](#Rs-unnamed2)
+* [SF.23: Keep forward declarations independent](#Rs-forward)
 
 ### <a name="Rs-file-suffix"></a>SF.1: Use a `.cpp` suffix for code files and `.h` for interface files if your project doesn't already follow another convention
 
@@ -19253,6 +19254,42 @@ An API class and its members can't live in an unnamed namespace; but any "helper
 ##### Enforcement
 
 * ???
+
+### <a name="#Rs-forward"></a>SF.23: Keep forward declarations independent
+
+##### Reason
+- Reading a forward declaration is easier since all the needed information is on the one line
+- Refactoring is easier because when a class moves namespaces only the lines that forward declare it must be changed. Renaming a namespace is still just a find and replace.
+- Merging is easier because each line is independent
+- Writing is easier because it's easier to decide where to insert (because it doesn't make a difference)
+
+##### Example
+
+Bad
+
+    namespace MyNamespace
+    {
+        namespace InnerNamespace
+        {
+            class C1;
+            class C2;
+        }
+        class C3;
+    }
+
+Good
+
+	namespace MyNamespace::InnerNamespace { class C1; }
+    namespace MyNamespace::InnerNamespace { class C2; }
+    namespace MyNamespace { class C3; }
+
+##### Note
+
+This assumes that namespace names are sufficiently short and nesting is sufficiently shallow to avoid violating any line length limits. If this is not the case, it may indicate namespace names are too long or deeply nested.
+
+##### Enforcement
+
+Warn on namespace blocks that contain more than one forward declaration.
 
 # <a name="S-stdlib"></a>SL: The Standard Library
 


### PR DESCRIPTION
Following from #1600 (after a glowing 2 out of 2 thumbs up)

As mentioned in the issue this rule is for the benefit of developers who use forward declarations and is irrelevant to those who don't. It's not advocating one way or the other.

I'm curious to know if this is how everyone does it and it just wasn't obvious to me or whether there are good reasons not to do it this way.

I also highlight that the reason given for closing #1248 was that modules make the problem go away which I think is also true here (?). Personally I would prefer the cpp core guidelines to be useful to me now rather than when my code is ported to c++20 but it's worth highlighting (if only to save people searching for precedent).

Note: The bad example may look worse than it needs to (it's not the way I'd have written it) but this is at the insistence of the linter.