### PR TITLE
CP.1: Simplify example, show good example, expand on rationale

### DIFF
--- a/scripts/hunspell/isocpp.dic
+++ b/scripts/hunspell/isocpp.dic
@@ -97,6 +97,7 @@ completers
 componentization
 composability
 composable
+ComputationCache
 conceptsTS
 cond
 const


### PR DESCRIPTION
"Make your code thread-safe" usually means "don't use global state."
Advice to replace global state with `thread_local` state is usually misguided.
https://quuxplusone.github.io/blog/2018/11/14/fiber-local-storage/