### PR TITLE
Exception for R.22

### DIFF
--- a/CppCoreGuidelines.md
+++ b/CppCoreGuidelines.md
@@ -9551,6 +9551,24 @@ Consider:
 
 The `make_shared()` version mentions `X` only once, so it is usually shorter (as well as faster) than the version with the explicit `new`.
 
+##### Exception
+
+Use explicit `new` when you must hold out-of-scope `weak_ptr` to your `shared_ptr` object to force resource block allocation/deallocation separately from control block. 
+
+Consider: 
+
+    {
+        weak_ptr<X> wp;
+        {
+        	auto sp = make_shared<X>();
+        	wp = sp;
+        }
+        // some long process, sp memory block still not released
+    }
+
+Memory allocated by `make_shared()` in this case will not be released until `wp` is reset or destroyed since its control block is still holding `wp` reference. With explicit `new` resource block can be safely released as soon as `sp` is destroyed.
+
+
 ##### Enforcement
 
 (Simple) Warn if a `shared_ptr` is constructed from the result of `new` rather than `make_shared`.

--- a/CppCoreGuidelines.md
+++ b/CppCoreGuidelines.md
@@ -9558,15 +9558,15 @@ Use explicit `new` when you must hold out-of-scope `weak_ptr` to your `shared_pt
 Consider: 
 
     {
-        weak_ptr<X> wp;
+        weak_ptr<X> weak;
         {
-            auto sp = make_shared<X>();    
-            wp = sp;
+            auto shared = make_shared<X>();
+            weak = shared;
         }
-        // some long process, sp memory block still not released
+        // some long process, destroyed memory block still not released
     }
 
-Memory allocated by `make_shared()` in this case will not be released until `wp` is reset or destroyed since its control block is still holding `wp` reference. With explicit `new` resource block can be safely released as soon as `sp` is destroyed.
+Memory allocated by `make_shared()` in this case will not be released until `weak` is reset or destroyed since its control block is still holding `weak` reference. With explicit `new` resource block can be safely released as soon as `shared` is destroyed.
 
 
 ##### Enforcement

--- a/CppCoreGuidelines.md
+++ b/CppCoreGuidelines.md
@@ -9560,8 +9560,8 @@ Consider:
     {
         weak_ptr<X> wp;
         {
-        	auto sp = make_shared<X>();
-        	wp = sp;
+            auto sp = make_shared<X>();    
+            wp = sp;
         }
         // some long process, sp memory block still not released
     }


### PR DESCRIPTION
Use explicit `new` instead of `make_shared()` when you must hold out-of-scope `weak_ptr` to your `shared_ptr` object to force resource block allocation/deallocation separately from control block. 

See detailed explanation here: https://dev.to/fenbf/how-a-weakptr-might-prevent-full-memory-cleanup-of-managed-object-i0i