### PR TITLE
SF.10: Fix annotation of examples

### DIFF
--- a/CppCoreGuidelines.md
+++ b/CppCoreGuidelines.md
@@ -19096,12 +19096,12 @@ Avoid surprises.
 Avoid having to change `#include`s if an `#include`d header changes.
 Avoid accidentally becoming dependent on implementation details and logically separate entities included in a header.
 
-##### Example
+##### Example, bad
 
     #include <iostream>
     using namespace std;
 
-    void use()                  // bad
+    void use()
     {
         string s;
         cin >> s;               // fine


### PR DESCRIPTION
In one example, a _bad_ annotation was marking a perfectly fine function
name instead of the incorrect local variable declaration.

In another example, a _fine_ annotation of the aforementioned variable
declaration was missing.