### PR TITLE
[NL.{11,15}] Bring rules in order

### DIFF
--- a/CppCoreGuidelines.md
+++ b/CppCoreGuidelines.md
@@ -21298,6 +21298,38 @@ ISO Standard, but with upper case used for your own types and concepts:
 
 Impossible.
 
+### <a name="Rl-literals"></a>NL.11: Make literals readable
+
+##### Reason
+
+Readability.
+
+##### Example
+
+Use digit separators to avoid long strings of digits
+
+    auto c = 299'792'458; // m/s2
+    auto q2 = 0b0000'1111'0000'0000;
+    auto ss_number = 123'456'7890;
+
+##### Example
+
+Use literal suffixes where clarification is needed
+
+    auto hello = "Hello!"s; // a std::string
+    auto world = "world";   // a C-style string
+    auto interval = 100ms;  // using <chrono>
+
+##### Note
+
+Literals should not be sprinkled all over the code as ["magic constants"](#Res-magic),
+but it is still a good idea to make them readable where they are defined.
+It is easy to make a typo in a long string of integers.
+
+##### Enforcement
+
+Flag long digit sequences. The trouble is to define "long"; maybe 7.
+
 ### <a name="Rl-space"></a>NL.15: Use spaces sparingly
 
 ##### Reason
@@ -21332,38 +21364,6 @@ This rule was added after many requests for guidance.
 ##### Note
 
 We value well-placed whitespace as a significant help for readability. Just don't overdo it.
-
-### <a name="Rl-literals"></a>NL.11: Make literals readable
-
-##### Reason
-
-Readability.
-
-##### Example
-
-Use digit separators to avoid long strings of digits
-
-    auto c = 299'792'458; // m/s2
-    auto q2 = 0b0000'1111'0000'0000;
-    auto ss_number = 123'456'7890;
-
-##### Example
-
-Use literal suffixes where clarification is needed
-
-    auto hello = "Hello!"s; // a std::string
-    auto world = "world";   // a C-style string
-    auto interval = 100ms;  // using <chrono>
-
-##### Note
-
-Literals should not be sprinkled all over the code as ["magic constants"](#Res-magic),
-but it is still a good idea to make them readable where they are defined.
-It is easy to make a typo in a long string of integers.
-
-##### Enforcement
-
-Flag long digit sequences. The trouble is to define "long"; maybe 7.
 
 ### <a name="Rl-order"></a>NL.16: Use a conventional class member declaration order
 


### PR DESCRIPTION
The rules NL.11 (Make literals readable) and NL.15 (Use spaces
sparingly) are placed in inverted order in the text flow, swap them.