### PR TITLE
Removed anti-CamelCase comments

### DIFF
--- a/CppCoreGuidelines.md
+++ b/CppCoreGuidelines.md
@@ -10688,7 +10688,7 @@ Readability. Limit the scope in which a variable can be used. Don't risk used-be
 
 ##### Example, bad
 
-    SomeLargeType var;   // ugly CaMeLcAsEvArIaBlE
+    SomeLargeType var;
 
     if (cond)   // some non-trivial condition
         Set(&var);
@@ -20956,7 +20956,7 @@ Most of the concepts below are defined in [the Ranges TS](http://www.open-std.or
 * `String`   // ???
 * `Number`   // ???
 * `Sortable`
-* `EqualityComparable`   // ???Must we suffer CaMelcAse???
+* `EqualityComparable`
 * `Convertible`
 * `Common`
 * `Boolean`


### PR DESCRIPTION
The anti-CamelCase comments are at odds with rule NL.8 which offers up CamelCase as a viable naming style.
https://isocpp.github.io/CppCoreGuidelines/CppCoreGuidelines#nl8-use-a-consistent-naming-style
