### PR TITLE
Use "naive" without diaeresis for consistency

### DIFF
--- a/CppCoreGuidelines.md
+++ b/CppCoreGuidelines.md
@@ -13433,7 +13433,7 @@ Alternatives for users
 This section contains rules for people who need high performance or low-latency.
 That is, these are rules that relate to how to use as little time and as few resources as possible to achieve a task in a predictably short time.
 The rules in this section are more restrictive and intrusive than what is needed for many (most) applications.
-Do not naïvely try to follow them in general code: achieving the goals of low latency requires extra work.
+Do not naively try to follow them in general code: achieving the goals of low latency requires extra work.
 
 Performance rule summary:
 


### PR DESCRIPTION
the alternate spelling also currently causes a spell checker alert. Sorry about this.