### PR TITLE
Fix typo in SL.str.1

### DIFF
--- a/CppCoreGuidelines.md
+++ b/CppCoreGuidelines.md
@@ -19645,7 +19645,7 @@ String summary:
 Note how `>>` and `!=` are provided for `string` (as examples of useful operations) and there are no explicit
 allocations, deallocations, or range checks (`string` takes care of those).
 
-In C++17, we might use `string_view` as the argument, rather than `const string*` to allow more flexibility to callers:
+In C++17, we might use `string_view` as the argument, rather than `const string&` to allow more flexibility to callers:
 
     vector<string> read_until(string_view terminator)   // C++17
     {


### PR DESCRIPTION
Part of SL.str.1 references replacing “const string*” with “string_view”, but the example code above shows “const string&” instead.
This changes the comment to the reference rather than pointer.