### PR TITLE
Add clarifying example to SF.12

### DIFF
--- a/CppCoreGuidelines.md
+++ b/CppCoreGuidelines.md
@@ -19306,6 +19306,7 @@ Nevertheless, the guidance is to use the quoted form for including files that ex
     #include <some_library/common.h> // A file that is not locally relative, included from another library; use the <> form
     #include "foo.h"                 // A file locally relative to foo.cpp in the same project, use the "" form
     #include "foo_utils/utils.h"     // A file locally relative to foo.cpp in the same project, use the "" form
+    #include <component_b/bar.h>     // A file in the same project located via a search path, use the <> form
 
 ##### Note
 


### PR DESCRIPTION
The examples in SF.12 are likely to encourage readers to always use the `""` form of `'#include` when including headers from the same project ([discussion](https://github.com/isocpp/CppCoreGuidelines/pull/1596#issuecomment-673266275)). However, in larger projects this may not always be appropriate; `<>` should be used for includes located via a header search path.

This proposed solution adds an example of the later, i.e. where `<>` is used to include a header from the same project.