### PR TITLE
E.30: Remove suggestion to use `throw()`

### DIFF
--- a/CppCoreGuidelines.md
+++ b/CppCoreGuidelines.md
@@ -16330,7 +16330,7 @@ For example, see [Stroustrup94](#Stroustrup94).
 
 ##### Note
 
-If no exception can be thrown, use [`noexcept`](#Re-noexcept) or its equivalent `throw()`.
+If no exception can be thrown, use [`noexcept`](#Re-noexcept).
 
 ##### Enforcement
 


### PR DESCRIPTION
Removed the suggestion to use `throw()` from E.30 ("Don't use exception specifications"), as it was deprecated by C++11, and is rejected by C++20.