### PR TITLE
Replace Travis CI with GitHub Actions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,18 @@
+name: build
+on: [push, pull_request]
+
+env:
+  apt: hunspell
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@master
+
+      - name: Run cd scripts; make -k
+        run: cd scripts; make -k
+      
+      - name: Run cd ..
+        run: cd ..

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,18 +1,20 @@
 name: build
 on: [push, pull_request]
 
-env:
-  apt: hunspell
-
 jobs:
   build:
     runs-on: ubuntu-latest
 
     steps:
       - uses: actions/checkout@master
-
+     
+      - name: Install Hunspell
+        run: |
+           sudo apt-get update
+           sudo apt-get install hunspell
+           
       - name: Run cd scripts; make -k
         run: cd scripts; make -k
-      
+
       - name: Run cd ..
         run: cd ..


### PR DESCRIPTION
Closes #1686.
Things added/changed:

- Switch from Travis CI to GitHub Actions.
