### PR TITLE
F.60: Remove C-style cast (T&) from example of invalid C++

### DIFF
--- a/CppCoreGuidelines.md
+++ b/CppCoreGuidelines.md
@@ -3439,7 +3439,7 @@ Sometimes having `nullptr` as an alternative to indicated "no object" is useful,
 
 ##### Note
 
-It is possible, but not valid C++ to construct a reference that is essentially a `nullptr` (e.g., `T* p = nullptr; T& r = (T&)*p;`).
+It is possible, but not valid C++ to construct a reference that is essentially a `nullptr` (e.g., `T* p = nullptr; T& r = *p;`).
 That error is very uncommon.
 
 ##### Note


### PR DESCRIPTION
The C-style cast in the example of constructing a `nullptr` reference appears unnecessary, in "F.60: Prefer T* over T& when “no argument” is a valid option". The example would also compile without any cast.

Of course, `T* p = nullptr; T& r = *p;` is still not valid C++, but that is according to the intention of the example.