### PR TITLE
Remove incoherent rule T.68

### DIFF
--- a/CppCoreGuidelines.md
+++ b/CppCoreGuidelines.md
@@ -16569,7 +16569,6 @@ Template definition rule summary:
 * [T.64: Use specialization to provide alternative implementations of class templates](#Rt-specialization)
 * [T.65: Use tag dispatch to provide alternative implementations of functions](#Rt-tag-dispatch)
 * [T.67: Use specialization to provide alternative implementations for irregular types](#Rt-specialization2)
-* [T.68: Use `{}` rather than `()` within templates to avoid ambiguities](#Rt-cast)
 * [T.69: Inside a template, don't make an unqualified non-member function call unless you intend it to be a customization point](#Rt-customization)
 
 Template and hierarchy rule summary:
@@ -18015,29 +18014,6 @@ When `concept`s become widely available such alternatives can be distinguished d
 ##### Enforcement
 
 ???
-
-### <a name="Rt-cast"></a>T.68: Use `{}` rather than `()` within templates to avoid ambiguities
-
-##### Reason
-
- `()` is vulnerable to grammar ambiguities.
-
-##### Example
-
-    template<typename T, typename U>
-    void f(T t, U u)
-    {
-        T v1(x);    // is v1 a function or a variable?
-        T v2 {x};   // variable
-        auto x = T(u);  // construction or cast?
-    }
-
-    f(1, "asdf"); // bad: cast from const char* to int
-
-##### Enforcement
-
-* flag `()` initializers
-* flag function-style casts
 
 
 ### <a name="Rt-customization"></a>T.69: Inside a template, don't make an unqualified non-member function call unless you intend it to be a customization point


### PR DESCRIPTION
T.68 currently seems to conflate two almost-issues-but-not-really.

- Using `T x(y);` can hit the Most Vexing Parse. `T x{y};` can't.
T.68 describes this as an "ambiguity," which of course it isn't;
the compiler considers that code completely unambiguous.
This issue has nothing to do with templates.

- Using `auto x = T(y);` can cause unexpected narrowing conversions,
or even cause a hidden `reinterpret_cast` or `const_cast`.
`T x(y);` can't. `auto x = T{y};` can't. This issue cannot possibly
be described as an "ambiguity," and has nothing to do with templates.
This is a pure duplicate of rule ES.23, "Prefer the `{}`-initializer syntax."

----

Finally, on the flip side, T.68 fails to point out that unicorn
initialization tends to *cause* ambiguities in template contexts
where you might not know what the constructor overload set of `T`
looks like.

For example, if `T` is `std::vector<std::string>`, then
`T(2).size() == 2`, `T(1).size() == 1`, and `T(0).size() == 0`.
Contrariwise,
`T{2}.size() == 2`, `T{1}.size() == 1`, and `T{0}.size()` segfaults.

If you're intending to hit a constructor with a specific signature
(such as in a template, like `make_shared` or `make_unique`), as
unambiguously as possible, you actually *should* use `T(x)` syntax.
So I would say not only was T.68 unsupported, its subject line
was actually precisely *backwards*, at least in the context of
"rules about templates."