### PR TITLE
Improve example in CP.4 to not contradict F.53.

### DIFF
--- a/CppCoreGuidelines.md
+++ b/CppCoreGuidelines.md
@@ -14085,12 +14085,11 @@ Application concepts are easier to reason about.
 
 ##### Example
 
-    void some_fun()
+    void some_fun(const std::string& msg)
     {
-        std::string msg, msg2;
-        std::thread publisher([&] { msg = "Hello"; });       // bad: less expressive
-                                                             //      and more error-prone
-        auto pubtask = std::async([&] { msg2 = "Hello"; });  // OK
+        std::thread publisher([=] { std::cout << msg; });      // bad: less expressive
+                                                               //      and more error-prone
+        auto pubtask = std::async([=] { std::cout << msg; });  // OK
         // ...
         publisher.join();
     }


### PR DESCRIPTION
Changed the example so that objects are not passed by reference to other thread contexts (though threads are properly synchronized).