### PR TITLE
Update reference to SF.7 to match text

### DIFF
--- a/CppCoreGuidelines.md
+++ b/CppCoreGuidelines.md
@@ -19046,7 +19046,7 @@ and M functions each containing a `using namespace X`with N lines of code in tot
 
 ##### Note
 
-[Don't write `using namespace` in a header file](#Rs-using-directive).
+[Don't write `using namespace` at global scope in a header file](#Rs-using-directive).
 
 ##### Enforcement
 


### PR DESCRIPTION
Looks like the rule was changed in 768e4620 and most references were updated but this one was missed. Since the meaning is quite different I've updated this text to match the rule.

Note #1667 in its current form does correctly update this text so supersedes this change when merged.