### PR TITLE
Fix C.127 example

### DIFF
--- a/CppCoreGuidelines.md
+++ b/CppCoreGuidelines.md
@@ -7144,6 +7144,7 @@ A class with a virtual function is usually (and in general) used via a pointer t
     // bad: derived from a class without a virtual destructor
     struct D : B {
         string s {"default"};
+        // ...
     };
 
     void use()


### PR DESCRIPTION
The example of C.127 won't compile because D is of abstract class type. ~Making `f()` non-pure virtual seems like the simplest fix.~