### PR TITLE
Update change_speed example in P.1 to use user-defined literal syntax

### DIFF
--- a/CppCoreGuidelines.md
+++ b/CppCoreGuidelines.md
@@ -551,7 +551,7 @@ A better approach is to be explicit about the meaning of the double (new speed o
     change_speed(Speed s);    // better: the meaning of s is specified
     // ...
     change_speed(2.3);        // error: no unit
-    change_speed(23m / 10s);  // meters per second
+    change_speed(23_m / 10s);  // meters per second
 
 We could have accepted a plain (unit-less) `double` as a delta, but that would have been error-prone.
 If we wanted both absolute speed and deltas, we would have defined a `Delta` type.


### PR DESCRIPTION
The example code
```cpp
change_speed(23m / 10s);
```
is not valid. `10s` is fine, because that is defined in `std::chrono_literals`, but I'm unaware of any `operator ""m` in the standard library.

I'm proposing changing this example to use user-defined literal syntax.