### PR TITLE
Proposing ES.48 Rule Exception for Upcasting

### DIFF
--- a/CppCoreGuidelines.md
+++ b/CppCoreGuidelines.md
@@ -11795,16 +11795,18 @@ If you have an object with multiple inheritance and you need to assign the base 
     struct derived_1 : base_1, base_2{};
     struct derived_2 : base_1, base_3{};
 
+    /*
+    * When base classes do not contain virtual members, they are laid out by order of appearance.
+    * However, bases with virtual members supercede the order of appearance. 
+    */
     void test_fn_bad(derived_1* d1, derived_2* d2)
     {
-        // When base classes do not contain virtual members the layout is defined by order of appearance.
         {
             void* v1 = d1;
             void* v2 = static_cast<base_2*>(d1); // cast to base_2 must be explicitly cast.
             // ...
         }
 
-        // base classes with virtual members supercede the order of appearance.
         {
             void* v1 = static_cast<base_1*>(d2); // cast to base_1 must be explicitly cast.
             void* v2 = d2;

--- a/CppCoreGuidelines.md
+++ b/CppCoreGuidelines.md
@@ -11797,14 +11797,14 @@ If you have an object with multiple inheritance and you need to assign the base 
 
     void test_fn_bad(derived_1* d1, derived_2* d2)
     {
-        // When the derived object's bases do not contain virtual members, the layout is defined by order of appearance.
+        // When the derived object's bases do not contain virtual members the layout is defined by order of appearance.
         {
             void* v1 = d1;
             void* v2 = static_cast<base_2*>(d1); // cast to base_2 must be explicitly cast.
             // ... 
         }
 
-        // Objects with virtual members supercede the order of appearance, so the upcast to base_3 can be implicit.
+        // Objects with virtual members supercede the order of appearance so the upcast to base_3 can be implicit.
         {
             void* v1 = static_cast<base_1*>(d2); // cast to base_1 must be explicitly cast.
             void* v2 = d2;
@@ -11816,13 +11816,13 @@ If you have an object with multiple inheritance and you need to assign the base 
     void test_fn_better(derived_1* d1, derived_2* d2)
     {
         {
-            void* v1 = static_cast<base_1*>(d1); // cast to base_1 could be implicit. Could be rewritten as `void* v1 = d1;`
+            void* v1 = static_cast<base_1*>(d1); // cast to base_1 could be implicit. 
             void* v2 = static_cast<base_2*>(d1); // cast to base_2 must be explicitly cast.
             // ... 
         }
         {
             void* v1 = static_cast<base_1*>(d2); // cast to base_1 must be explicitly cast.
-            void* v2 = static_cast<base_3*>(d2); 
+            void* v2 = static_cast<base_3*>(d2); // cast to base_3 could be implicit.
             // ... 
         }
     }

--- a/CppCoreGuidelines.md
+++ b/CppCoreGuidelines.md
@@ -11795,7 +11795,6 @@ If you have an object with multiple inheritance and you need to assign the base 
     struct derived_1 : base_1, base_2{};
     struct derived_2 : base_1, base_3{};
 
-    // The following comments regarding memory layout are only true for compilers that follow the Itanium ABI
     void test_fn_bad(derived_1* d1, derived_2* d2)
     {
         // When the derived object's bases do not contain virtual members, the layout is defined by order of appearance.

--- a/CppCoreGuidelines.md
+++ b/CppCoreGuidelines.md
@@ -11774,7 +11774,9 @@ If you deliberately want to discard such a result, first think hard about whethe
 If you still think it's appropriate and your code reviewer agrees, use `std::ignore =` to turn off the warning which is simple, portable, and easy to grep.
 
 ##### Exception for implicit casts<a name="es_48-implicit-cast-exception"></a>
-If you have an object with multiple inheritance and you need to assign the base classes to `void*`, the upcast should be done explicitly. This increases readability of the code and reduces the guesswork in determining which cast could be performed implicitly. See the example below:
+If you have an object with multiple inheritance and you need to assign the base classes to `void*`, the up cast should be done explicitly. This increases readability of the code and reduces the guesswork in determining which cast could be performed implicitly. 
+
+###### Example: 
 
     struct base_1
     {
@@ -11843,7 +11845,7 @@ Casts are widely (mis)used. Modern C++ has rules and constructs that eliminate t
 * Flag all C-style casts, including to `void`.
 * Flag functional style casts using `Type(value)`. Use `Type{value}` instead which is not narrowing. (See [ES.64](#Res-construct).)
 * Flag [identity casts](#Pro-type-identitycast) between pointer types, where the source and target types are the same (#Pro-type-identitycast).
-* Flag an explicit pointer cast that could be [implicit](#Pro-type-implicitpointercast), except when upcasting [classes with multiple inheritance](#es_48-implicit-cast-exception).
+* Flag an explicit pointer cast that could be [implicit](#Pro-type-implicitpointercast), except when up casting [classes with multiple inheritance](#es_48-implicit-cast-exception).
 
 ### <a name="Res-casts-named"></a>ES.49: If you must use a cast, use a named cast
 

--- a/CppCoreGuidelines.md
+++ b/CppCoreGuidelines.md
@@ -11774,6 +11774,7 @@ If you deliberately want to discard such a result, first think hard about whethe
 If you still think it's appropriate and your code reviewer agrees, use `std::ignore =` to turn off the warning which is simple, portable, and easy to grep.
 
 ##### Exception for implicit casts<a name="es_48-implicit-cast-exception"></a>
+
 If you have an object with multiple inheritance and you need to assign the base classes to `void*`, the up cast should be done explicitly. This increases readability of the code and reduces the guesswork in determining which cast could be performed implicitly. 
 
 ###### Example: 

--- a/CppCoreGuidelines.md
+++ b/CppCoreGuidelines.md
@@ -11797,18 +11797,18 @@ If you have an object with multiple inheritance and you need to assign the base 
 
     void test_fn_bad(derived_1* d1, derived_2* d2)
     {
-        // When the derived object's bases do not contain virtual members the layout is defined by order of appearance.
+        // When base classes do not contain virtual members the layout is defined by order of appearance.
         {
             void* v1 = d1;
             void* v2 = static_cast<base_2*>(d1); // cast to base_2 must be explicitly cast.
-            // ... 
+            // ...
         }
 
-        // Objects with virtual members supercede the order of appearance so the upcast to base_3 can be implicit.
+        // base classes with virtual members supercede the order of appearance.
         {
             void* v1 = static_cast<base_1*>(d2); // cast to base_1 must be explicitly cast.
             void* v2 = d2;
-            // ... 
+            // ...
         }
     }
 
@@ -11816,14 +11816,14 @@ If you have an object with multiple inheritance and you need to assign the base 
     void test_fn_better(derived_1* d1, derived_2* d2)
     {
         {
-            void* v1 = static_cast<base_1*>(d1); // cast to base_1 could be implicit. 
+            void* v1 = static_cast<base_1*>(d1); // cast to base_1 could be implicit.
             void* v2 = static_cast<base_2*>(d1); // cast to base_2 must be explicitly cast.
-            // ... 
+            // ...
         }
         {
             void* v1 = static_cast<base_1*>(d2); // cast to base_1 must be explicitly cast.
             void* v2 = static_cast<base_3*>(d2); // cast to base_3 could be implicit.
-            // ... 
+            // ...
         }
     }
 


### PR DESCRIPTION
Proposing to add an exception to es.48 in instances where the implicit cast involves upcasting objects with multiple inheritance. Due to the various rules that define memory layout it is not always clear to the average developer which upcasts can be performed implicitly. 