### PR TITLE
Do not allocate an excessive amount of memory in example code.

### DIFF
--- a/CppCoreGuidelines.md
+++ b/CppCoreGuidelines.md
@@ -20613,7 +20613,7 @@ and errors (when we didn't deal correctly with semi-constructed objects consiste
             : mx(check_size(x))
             , my(check_size(y))
             // now we know x and y have a valid size
-            , data(mx*my*sizeof(int)) // will throw std::bad_alloc on error
+            , data(mx * my) // will throw std::bad_alloc on error
         {
             // picture is ready-to-use
         }


### PR DESCRIPTION
This reverts commit de20b33dabfda58b1bf210450b2e61d71e552e67.

See [this comment](https://github.com/isocpp/CppCoreGuidelines/commit/de20b33dabfda58b1bf210450b2e61d71e552e67#r50815941).