### PR TITLE
C.164: Clarify enforcement

### DIFF
--- a/CppCoreGuidelines.md
+++ b/CppCoreGuidelines.md
@@ -8326,7 +8326,7 @@ The string returned by `ff()` is destroyed before the returned pointer into it c
 
 ##### Enforcement
 
-Flag all conversion operators.
+Flag all non-explicit conversion operators.
 
 ### <a name="Ro-custom"></a>C.165: Use `using` for customization points
 


### PR DESCRIPTION
Concerns [C.164](https://github.com/isocpp/CppCoreGuidelines/blob/master/CppCoreGuidelines.md#c164-avoid-implicit-conversion-operators).

C.164 recommends avoiding implicit conversion operators and using `explicit` ones instead.
However, the rule's enforcement enforces to flag *all* conversion operators. 

In my opinion, this enforcement does not coincide with what the rest of the rule states.

Thus, the enforcement was rewritten and (hopefully) clarified. It now coincides with the rule's message. 

