### PR TITLE
R.34-36 shared_ptr

### DIFF
--- a/CppCoreGuidelines.md
+++ b/CppCoreGuidelines.md
@@ -9822,7 +9822,7 @@ This makes the function's ownership sharing explicit.
     public:
         // WidgetUser will share ownership of the widget
         WidgetUser(std::shared_ptr<widget> w) :
-            m_widget{w} {}
+            m_widget{std::move(w)} {}
         // ...
     private:
         std::shared_ptr<widget> m_widget;

--- a/CppCoreGuidelines.md
+++ b/CppCoreGuidelines.md
@@ -9858,6 +9858,26 @@ This makes the function's reseating explicit.
 * (Simple) ((Foundation)) Warn if a function takes a `Shared_pointer<T>` by value or by reference to `const` and does not copy or move it to another `Shared_pointer` on at least one code path. Suggest taking a `T*` or `T&` instead.
 * (Simple) ((Foundation)) Warn if a function takes a `Shared_pointer<T>` by rvalue reference. Suggesting taking it by value instead.
 
+### <a name="Rr-sharedptrparam-const"></a>R.36: Take a `const shared_ptr<widget>&` parameter to express that it might retain a reference count to the object ???
+
+##### Reason
+
+This makes the function's ??? explicit.
+
+##### Example, good
+
+    void share(shared_ptr<widget>);            // share -- "will" retain refcount
+
+    void reseat(shared_ptr<widget>&);          // "might" reseat ptr
+
+    void may_share(const shared_ptr<widget>&); // "might" retain refcount
+
+##### Enforcement
+
+* (Simple) Warn if a function takes a `Shared_pointer<T>` parameter by lvalue reference and does not either assign to it or call `reset()` on it on at least one code path. Suggest taking a `T*` or `T&` instead.
+* (Simple) ((Foundation)) Warn if a function takes a `Shared_pointer<T>` by value or by reference to `const` and does not copy or move it to another `Shared_pointer` on at least one code path. Suggest taking a `T*` or `T&` instead.
+* (Simple) ((Foundation)) Warn if a function takes a `Shared_pointer<T>` by rvalue reference. Suggesting taking it by value instead.
+
 ### <a name="Rr-smartptrget"></a>R.37: Do not pass a pointer or reference obtained from an aliased smart pointer
 
 ##### Reason

--- a/CppCoreGuidelines.md
+++ b/CppCoreGuidelines.md
@@ -9137,6 +9137,7 @@ Here, we ignore such cases.
   * [R.33: Take a `unique_ptr<widget>&` parameter to express that a function reseats the `widget`](#Rr-reseat)
   * [R.34: Take a `shared_ptr<widget>` parameter to express shared ownership](#Rr-sharedptrparam-owner)
   * [R.35: Take a `shared_ptr<widget>&` parameter to express that a function might reseat the shared pointer](#Rr-sharedptrparam)
+  * [R.36: Take a `const shared_ptr<widget>&` parameter to express that it might retain a reference count to the object ???](#Rr-sharedptrparam-const)
   * [R.37: Do not pass a pointer or reference obtained from an aliased smart pointer](#Rr-smartptrget)
 
 ### <a name="Rr-raii"></a>R.1: Manage resources automatically using resource handles and RAII (Resource Acquisition Is Initialization)

--- a/CppCoreGuidelines.md
+++ b/CppCoreGuidelines.md
@@ -9821,7 +9821,7 @@ This makes the function's ownership sharing explicit.
     {
     public:
         // WidgetUser will share ownership of the widget
-        WidgetUser(std::shared_ptr<widget> w) :
+        explicit WidgetUser(std::shared_ptr<widget> w) noexcept:
             m_widget{std::move(w)} {}
         // ...
     private:

--- a/scripts/hunspell/isocpp.dic
+++ b/scripts/hunspell/isocpp.dic
@@ -645,6 +645,7 @@ webby
 Webcolor
 webcolors
 WG21
+WidgetUser
 WorkQueue
 'widen'
 x1

--- a/scripts/hunspell/isocpp.dic
+++ b/scripts/hunspell/isocpp.dic
@@ -552,6 +552,7 @@ Stroustrup15
 Stroustrup94
 Stroustrup's
 struct
+structs
 suboperations
 subsetting
 sum1


### PR DESCRIPTION
I added some examples for R.34 and R.35 for Issue #1753.  I couldn't come up with a good example for R.36 so I ended up deleting it (hope that is OK).  I couldn't think of a good/safe use for a function to know the reference count.  It seems like it wouldn't be common enough to have its own rule.

I also made a slight wording change to the title of R.34 to not imply that the function itself is owning the object.

Thanks for writing/maintaing these guidelines.
