### PR TITLE
Add CP.52 and CP.53 guidelines, closes #1805, closes #1806

### DIFF
--- a/CppCoreGuidelines.md
+++ b/CppCoreGuidelines.md
@@ -15137,7 +15137,9 @@ Once a coroutine reaches the first suspension point, such as a co_await, the syn
     std::future<int> Class::do_something(const std::shared_ptr<int>& input)
     {
         co_await something();
-        co_return *input + 1; // DANGER: the reference to input is no longer valid and may be freed memory
+        
+        // DANGER: the reference to input is no longer valid and may be freed memory
+        co_return *input + 1;
     }
 
 ##### Example, Good

--- a/CppCoreGuidelines.md
+++ b/CppCoreGuidelines.md
@@ -15024,7 +15024,7 @@ Coroutine rule summary:
 
 * [CP.51: Do not use capturing lambdas that are coroutines](#Rcoro-capture)
 * [CP.52: Do not hold locks or other synchronization primitives across suspension points](#Rcoro-locks)
-* [CP.53: Parameters to coroutines should not be passed by reference](#Rcoro-reference-params)
+* [CP.53: Parameters to coroutines should not be passed by reference](#Rcoro-reference-parameters)
 
 ### <a name="Rcoro-capture"></a>CP.51: Do not use capturing lambdas that are coroutines
 
@@ -15126,7 +15126,7 @@ This pattern is also bad for performance. When a suspension point is reached, su
 
 Flag all lock guards that are not destructed before a coroutine suspends.
 
-### <a name="Rcoro-reference-params"></a>CP.53: Parameters to coroutines should not be passed by reference
+### <a name="Rcoro-reference-parameters"></a>CP.53: Parameters to coroutines should not be passed by reference
 
 ##### Reason
 
@@ -15137,7 +15137,7 @@ Once a coroutine reaches the first suspension point, such as a co_await, the syn
     std::future<int> Class::do_something(const std::shared_ptr<int>& input)
     {
         co_await something();
-        
+
         // DANGER: the reference to input is no longer valid and may be freed memory
         co_return *input + 1;
     }

--- a/CppCoreGuidelines.md
+++ b/CppCoreGuidelines.md
@@ -15138,7 +15138,7 @@ Once a coroutine reaches the first suspension point, such as a co_await, the syn
     {
         co_await something();
 
-        // DANGER: the reference to input is no longer valid and may be freed memory
+        // DANGER: the reference to input may no longer be valid and may be freed memory
         co_return *input + 1;
     }
 
@@ -15152,7 +15152,7 @@ Once a coroutine reaches the first suspension point, such as a co_await, the syn
 
 ##### Note
 
-This problem does not apply to reference parameters that are only accessed before the first suspension point. Subsequent changes to the function may add or move suspension points which would reintroduce this class of bug. It is safer to always pass by value because the copied parameter will live in the coroutine frame that is safe to access throughout the coroutine.
+This problem does not apply to reference parameters that are only accessed before the first suspension point. Subsequent changes to the function may add or move suspension points which would reintroduce this class of bug. Some types of coroutines have the suspension point before the first line of code in the coroutine executes, in which case reference parameters are always unsafe.  It is safer to always pass by value because the copied parameter will live in the coroutine frame that is safe to access throughout the coroutine.
 
 ##### Note
 


### PR DESCRIPTION
Address the following two issues by adding new core guidelines (CP.52 and CP.53)

#1805 [Proposal] Locks or other synchronization primitives should not be held across suspension points in a coroutine (CP.coro section)
#1806 [Proposal] Parameters to coroutines should not be passed by reference (CP.coro section)

These guidelines are adjacent in the document so I'm creating a single pull request to avoid having to resolve merge conflicts with myself.

resolves #1805, resolves #1806