### PR TITLE
ES.46 Issue 1797 - narrowing to bool

### DIFF
--- a/CppCoreGuidelines.md
+++ b/CppCoreGuidelines.md
@@ -11712,7 +11712,7 @@ We also include lossy arithmetic casts, such as from a negative floating point t
     double d = -7.9;
     unsigned u = 0;
 
-    u = d;                               // BAD
+    u = d;                               // bad: narrowing
     u = gsl::narrow_cast<unsigned>(d);   // OK (you asked for it): u becomes 4294967289
     u = gsl::narrow<unsigned>(d);        // OK: throws narrowing_error
 
@@ -11720,7 +11720,7 @@ We also include lossy arithmetic casts, such as from a negative floating point t
 
 This rule does not apply to values that are used as a condition:
 
-    if (ptr) do_something(ptr);   // OK: ptr is used as a condition
+    if (ptr) do_something(*ptr);   // OK: ptr is used as a condition
     bool b = ptr;                 // bad: narrowing
 
 ##### Enforcement

--- a/CppCoreGuidelines.md
+++ b/CppCoreGuidelines.md
@@ -11718,7 +11718,7 @@ We also include lossy arithmetic casts, such as from a negative floating point t
 
 ##### Note
 
-This rule does not apply to values that are used as a condition:
+This rule does not apply to [contextual conversions to bool](https://en.cppreference.com/w/cpp/language/implicit_conversion#Contextual_conversions):
 
     if (ptr) do_something(*ptr);   // OK: ptr is used as a condition
     bool b = ptr;                  // bad: narrowing

--- a/CppCoreGuidelines.md
+++ b/CppCoreGuidelines.md
@@ -11704,8 +11704,8 @@ A key example is basic narrowing:
 
 The guidelines support library offers a `narrow_cast` operation for specifying that narrowing is acceptable and a `narrow` ("narrow if") that throws an exception if a narrowing would throw away legal values:
 
-    i = narrow_cast<int>(d);   // OK (you asked for it): narrowing: i becomes 7
-    i = narrow<int>(d);        // OK: throws narrowing_error
+    i = gsl::narrow_cast<int>(d);   // OK (you asked for it): narrowing: i becomes 7
+    i = gsl::narrow<int>(d);        // OK: throws narrowing_error
 
 We also include lossy arithmetic casts, such as from a negative floating point type to an unsigned integral type:
 
@@ -11713,8 +11713,15 @@ We also include lossy arithmetic casts, such as from a negative floating point t
     unsigned u = 0;
 
     u = d;                          // BAD
-    u = narrow_cast<unsigned>(d);   // OK (you asked for it): u becomes 4294967289
-    u = narrow<unsigned>(d);        // OK: throws narrowing_error
+    u = gsl::narrow_cast<unsigned>(d);   // OK (you asked for it): u becomes 4294967289
+    u = gsl::narrow<unsigned>(d);        // OK: throws narrowing_error
+
+##### Note
+
+This rule does not apply to values that are used as a condition:
+    
+    if (ptr) do_something(ptr);   // OK: ptr is used as a condition
+    bool b = ptr;                 // bad: narrowing
 
 ##### Enforcement
 

--- a/CppCoreGuidelines.md
+++ b/CppCoreGuidelines.md
@@ -11721,7 +11721,7 @@ We also include lossy arithmetic casts, such as from a negative floating point t
 This rule does not apply to values that are used as a condition:
 
     if (ptr) do_something(*ptr);   // OK: ptr is used as a condition
-    bool b = ptr;                 // bad: narrowing
+    bool b = ptr;                  // bad: narrowing
 
 ##### Enforcement
 

--- a/CppCoreGuidelines.md
+++ b/CppCoreGuidelines.md
@@ -11719,7 +11719,7 @@ We also include lossy arithmetic casts, such as from a negative floating point t
 ##### Note
 
 This rule does not apply to values that are used as a condition:
-    
+
     if (ptr) do_something(ptr);   // OK: ptr is used as a condition
     bool b = ptr;                 // bad: narrowing
 

--- a/CppCoreGuidelines.md
+++ b/CppCoreGuidelines.md
@@ -11712,7 +11712,7 @@ We also include lossy arithmetic casts, such as from a negative floating point t
     double d = -7.9;
     unsigned u = 0;
 
-    u = d;                          // BAD
+    u = d;                               // BAD
     u = gsl::narrow_cast<unsigned>(d);   // OK (you asked for it): u becomes 4294967289
     u = gsl::narrow<unsigned>(d);        // OK: throws narrowing_error
 


### PR DESCRIPTION
Added note for narrowing to bool. See  #1797.

Also qualified gsl::narrow