### PR TITLE
 C.147: Add missing example.

### DIFF
--- a/CppCoreGuidelines.md
+++ b/CppCoreGuidelines.md
@@ -8062,7 +8062,39 @@ Casting to a reference expresses that you intend to end up with a valid object, 
 
 ##### Example
 
-    ???
+    struct A // some interface
+    {
+        virtual void f() = 0; // make A polymorphic
+    };
+
+    struct B : public A
+    {
+        void f() override {}
+        void member_fn() {}
+    };
+
+    struct SimilarToB
+    {
+        void member_fn() {}
+    };
+
+    // if you can't avoid casting
+
+    A* ptr = new B;
+
+    // bad, cast successful, but no check
+    dynamic_cast<B*>(ptr)->member_fn();
+    // bad, cast fails, call of member_fn is undefined behavior.
+    dynamic_cast<SimilarToB*>(ptr)->member_fn();
+
+    // better, runtime check
+    dynamic_cast<B&>(*ptr).member_fn();
+    // better, instead of undefined behavior, throw std::bad_cast, so you can find the bug.
+    dynamic_cast<SimilarToB&>(*ptr).member_fn();
+
+
+##### Notes
+Compile with -fsanitize=undefined (GCC and Clang) to find undefined behavior.
 
 ##### Enforcement
 

--- a/scripts/hunspell/isocpp.dic
+++ b/scripts/hunspell/isocpp.dic
@@ -15,6 +15,7 @@
 98's
 à
 a1
+A
 A1
 a2
 A2
@@ -53,6 +54,7 @@ asio
 AST
 async
 AUTOSAR
+B
 'B'
 b2
 BDE
@@ -305,6 +307,7 @@ mallocfree
 Mathematizing
 maul2
 md
+member_fn
 memberinit
 members'
 memcmp
@@ -513,6 +516,7 @@ sharedptrparam
 setjmp
 SignedIntegral
 signedness
+SimilarToB
 simpleFunc
 'size'
 sizeof


### PR DESCRIPTION
C.147: Add missing example.

Let me know if you think this is a suitable example to illustrate usage of `dynamic_cast<T&>`.