### PR TITLE
C.130: drop a destructor in the D class

### DIFF
--- a/CppCoreGuidelines.md
+++ b/CppCoreGuidelines.md
@@ -7493,7 +7493,6 @@ Copying a polymorphic class is discouraged due to the slicing problem, see [C.67
 
     class D : public B {
     public:
-        ~D() override {};
         gsl::owner<D*> clone() const override
         {
             return new D{*this};


### PR DESCRIPTION
To follow the Rule of Zero.

#1423