### PR TITLE
F.48 Add exception for subobjects and structured bindings

### DIFF
--- a/CppCoreGuidelines.md
+++ b/CppCoreGuidelines.md
@@ -3803,6 +3803,24 @@ With guaranteed copy elision, it is now almost always a pessimization to express
       return result;
     }
 
+##### Exception
+
+Prior to C++20, subobjects of local variables are not considered as move candidates. Therefore, it is acceptable to return a moved subobject of a local variable. 
+
+    std::string f()
+    {
+        auto pp = std::make_pair("Hello, world! I am a long string."s, 1.0);
+        return std::move(pp.first);
+    }
+
+Since structured-bindings denote subobjects, the same applies to structured bindings.
+
+    std::string f()
+    {
+        auto [msg, val] = std::make_pair("Hello, world! I am a long string."s, 1.0);
+        return std::move(msg);
+    }
+
 ##### Enforcement
 
 This should be enforced by tooling by checking the return expression .

--- a/scripts/hunspell/isocpp.dic
+++ b/scripts/hunspell/isocpp.dic
@@ -335,6 +335,7 @@ modify1
 modify2
 moredata
 *multithreaded
+msg
 msgsl
 mtx
 Murray93
@@ -413,6 +414,7 @@ polymorphically
 POPL
 PortHandle
 PostInitialize
+pp
 pp216
 PPP
 pragma
@@ -620,6 +622,7 @@ v1
 v17
 v2
 va
+val
 ValueType
 vararg
 varargs


### PR DESCRIPTION
Prior to C++20's [P1825R0](http://www.open-std.org/jtc1/sc22/wg21/docs/papers/2019/p1825r0.html), subobjects of local variables are not considered as move candidates. This can lead to a costly copy when trying to return a subobject of a local or a structured binding. This PR notes an exception to F.48 for this reason.

Here is a live example:
https://godbolt.org/z/fjMKhbMjd