### PR TITLE
code formating fix: +1 new line

### DIFF
--- a/CppCoreGuidelines.md
+++ b/CppCoreGuidelines.md
@@ -12912,6 +12912,7 @@ Multiple case labels of a single statement is OK:
     }
 
 Return statements in a case label are also OK:
+
     switch (x) {
     case 'a':
         return 1;


### PR DESCRIPTION
One more new line is necessary after the text "Return statements in a case label are also OK:" to make the code excerpt after it be formatted as code.