### PR TITLE
Added example for SF.21

### DIFF
--- a/CppCoreGuidelines.md
+++ b/CppCoreGuidelines.md
@@ -19595,7 +19595,26 @@ It is almost always a bug to mention an unnamed namespace in a header file.
 
 ##### Example
 
-    ???
+    // file foo.h:
+    namespace
+    {
+        const double x = 1.234;  // bad
+
+        double foo(double y)     // bad
+        {
+            return y + x;
+        } 
+    }
+
+    namespace Foo
+    {
+        inline constexpr double x = 1.234; // good
+
+        inline double foo(double y)        // good
+        {
+            return y + x;
+        }
+    }
 
 ##### Enforcement
 

--- a/CppCoreGuidelines.md
+++ b/CppCoreGuidelines.md
@@ -19603,7 +19603,7 @@ It is almost always a bug to mention an unnamed namespace in a header file.
         double foo(double y)     // bad
         {
             return y + x;
-        } 
+        }
     }
 
     namespace Foo

--- a/scripts/hunspell/isocpp.dic
+++ b/scripts/hunspell/isocpp.dic
@@ -657,12 +657,14 @@ WG21
 WidgetUser
 WorkQueue
 'widen'
+x
 x1
 x2
 x22
 xmax
 xor
 Xs
+y
 years'
 yy
 Zhuang

--- a/scripts/hunspell/isocpp.dic
+++ b/scripts/hunspell/isocpp.dic
@@ -657,14 +657,12 @@ WG21
 WidgetUser
 WorkQueue
 'widen'
-x
 x1
 x2
 x22
 xmax
 xor
 Xs
-y
 years'
 yy
 Zhuang


### PR DESCRIPTION
Added Example for SF.21 'Don't use an unnamed (anonymous) namespace in a header'