### PR TITLE
formatting typo

### DIFF
--- a/CppCoreGuidelines.md
+++ b/CppCoreGuidelines.md
@@ -4485,7 +4485,7 @@ Prefer the order `public` members before `protected` members before `private` me
 ##### Enforcement
 
 * [Flag protected data](#Rh-protected).
-* Flag mixtures of `public` and private `data`
+* Flag mixtures of `public` and `private` data
 
 ## <a name="SS-concrete"></a>C.concrete: Concrete types
 


### PR DESCRIPTION
To me it looks like this is a formatting type. I don't see why data should be emphasized. The point is in mixing `public` and `private`, so these both should be emphasized, not `public` and `data`.