### PR TITLE
Clean up and add example for C.32 - raw pointers

### DIFF
--- a/CppCoreGuidelines.md
+++ b/CppCoreGuidelines.md
@@ -4642,7 +4642,7 @@ Destructor rules:
 
 * [C.30: Define a destructor if a class needs an explicit action at object destruction](#Rc-dtor)
 * [C.31: All resources acquired by a class must be released by the class's destructor](#Rc-dtor-release)
-* [C.32: If a class has a raw pointer (`T*`) or reference (`T&`), consider whether it might be owning](#Rc-dtor-ptr)
+* [C.32: If a class has a raw pointer (`T*`), consider whether it might be owning](#Rc-dtor-ptr)
 * [C.33: If a class has an owning pointer member, define a destructor](#Rc-dtor-ptr2)
 * [C.35: A base class destructor should be either public and virtual, or protected and non-virtual](#Rc-dtor-virtual)
 * [C.36: A destructor must not fail](#Rc-dtor-fail)
@@ -4985,7 +4985,7 @@ Here `p` refers to `pp` but does not own it.
 * (Hard) Determine if pointer or reference member variables are owners when there is no explicit statement of ownership
   (e.g., look into the constructors).
 
-### <a name="Rc-dtor-ptr"></a>C.32: If a class has a raw pointer (`T*`) or reference (`T&`), consider whether it might be owning
+### <a name="Rc-dtor-ptr"></a>C.32: If a class has a raw pointer (`T*`), consider whether it might be owning
 
 ##### Reason
 
@@ -4993,16 +4993,23 @@ There is a lot of code that is non-specific about ownership.
 
 ##### Example
 
-    ???
+    class LegacyClass
+    {
+        Foo* m_owningPtr;
+        Bar* m_observerPtr;
+    }
+
+The only way to determine ownership may be to dig through the code to look for
+allocations.  If a pointer is owning, document it as owning.
 
 ##### Note
 
-If the `T*` or `T&` is owning, mark it `owning`. If the `T*` is not owning, consider marking it `ptr`.
-This will aid documentation and analysis.
+Ownership should be clear in new code (and refactored legacy code) according to [R.20](#Rr-owner) for owned
+resources and [R.3](#Rr-ptr) for non-owned resources.
 
 ##### Enforcement
 
-Look at the initialization of raw member pointers and member references and see if an allocation is used.
+Look at the initialization of raw member pointers and see if an allocation is used.
 
 ### <a name="Rc-dtor-ptr2"></a>C.33: If a class has an owning pointer member, define a destructor
 

--- a/CppCoreGuidelines.md
+++ b/CppCoreGuidelines.md
@@ -4997,6 +4997,7 @@ There is a lot of code that is non-specific about ownership.
     {
         Foo* m_owningPtr;
         Bar* m_observerPtr;
+        // ...
     }
 
 The only way to determine ownership may be to dig through the code to look for

--- a/CppCoreGuidelines.md
+++ b/CppCoreGuidelines.md
@@ -19558,7 +19558,26 @@ It is almost always a bug to mention an unnamed namespace in a header file.
 
 ##### Example
 
-    ???
+    // file foo.h:
+    namespace
+    {
+        const double x = 1.234;  // bad
+
+        double foo(double y)     // bad
+        {
+            return y + x;
+        }
+    }
+
+    namespace Foo
+    {
+        inline constexpr double x = 1.234; // good
+
+        inline double foo(double y)        // good
+        {
+            return y + x;
+        }
+    }
 
 ##### Enforcement
 

--- a/CppCoreGuidelines.md
+++ b/CppCoreGuidelines.md
@@ -3749,6 +3749,7 @@ Declaring `main` (the one global `main` of a program) `void` limits portability.
 ##### Note
 
 We mention this only because of the persistence of this error in the community.
+Note that despite its non-void return type, the main function does not require an explicit return statement.
 
 ##### Enforcement
 

--- a/CppCoreGuidelines.md
+++ b/CppCoreGuidelines.md
@@ -19571,7 +19571,7 @@ It is almost always a bug to mention an unnamed namespace in a header file.
 
     namespace Foo
     {
-        inline constexpr double x = 1.234; // good
+        const double x = 1.234; // good
 
         inline double foo(double y)        // good
         {

--- a/scripts/hunspell/isocpp.dic
+++ b/scripts/hunspell/isocpp.dic
@@ -392,6 +392,7 @@ optimizable
 O'Reilly
 org
 ostream
+ostringstream
 overabstract
 overconstrain
 overconstrained

--- a/scripts/hunspell/isocpp.dic
+++ b/scripts/hunspell/isocpp.dic
@@ -286,6 +286,7 @@ Lakos
 Lakos96
 Lavavej
 LCSD05
+LegacyClass
 lifecycle
 *life-time
 linearization
@@ -301,6 +302,8 @@ lvalues
 m1
 m2
 m3
+m_owningPtr;
+m_observerPtr;
 macros2
 malloc
 mallocfree


### PR DESCRIPTION
Added a simple example for [C.32: If a class has a raw pointer (`T*`), consider whether it might be owning](https://github.com/isocpp/CppCoreGuidelines/blob/master/CppCoreGuidelines.md#Rc-dtor-ptr)

Also removed mentioning of owning references.  I think owning referecnce are rare and generally not a problem in legacy code.  
R.3 gives an exception for legacy code to have owing raw pointers but R.4 does not for owning references.  If we want to keep the owing references C.33 should probably be updated to delete owing references.