### PR TITLE
SL.io.50 (Avoid `endl`): Mention string streams

### DIFF
--- a/CppCoreGuidelines.md
+++ b/CppCoreGuidelines.md
@@ -20308,6 +20308,14 @@ For writing to a file, there is rarely a need to `flush`.
 
 ##### Note
 
+For string streams (specifically `ostringstream`), the insertion of an `endl` is entirely equivalent
+to the insertion of a `'\n'` character, but also in this case, `endl` might be significantly slower.
+
+`endl` does *not* take care of producing a platform specific end-of-line sequence (like "\r\n" on
+Windows). So for a string stream, `s << endl` just inserts a *single* character, `'\n'`.
+
+##### Note
+
 Apart from the (occasionally important) issue of performance,
 the choice between `'\n'` and `endl` is almost completely aesthetic.
 

--- a/scripts/hunspell/isocpp.dic
+++ b/scripts/hunspell/isocpp.dic
@@ -389,6 +389,7 @@ optimizable
 O'Reilly
 org
 ostream
+ostringstream
 overabstract
 overconstrain
 overconstrained


### PR DESCRIPTION
Explicitly mentioned string streams as `endl` insertions into string streams do actually occur in the wild.

People have been wondering whether `endl` is specifically useful for a stringstream to get a _platform-specific_ end-of-line character sequence (apparently not): 
"Inserting endline into a stringstream"
https://stackoverflow.com/questions/6865398/inserting-endline-into-a-stringstream

But there have also been concerns about the performance effect of `endl` on an `ostringstream`:
"Why does using std::endl with ostringstream affect output speed?"
https://stackoverflow.com/questions/12675273/why-does-using-stdendl-with-ostringstream-affect-output-speed
