### PR TITLE
Fix GitHub Actions build warnings, Marker style should be `*`

### DIFF
--- a/CppCoreGuidelines.md
+++ b/CppCoreGuidelines.md
@@ -16129,17 +16129,17 @@ The standard library assumes that destructors, deallocation functions (e.g., `op
 
 ##### Note
 
-- Deallocation functions, including `operator delete`, must be `noexcept`.
-- `swap` functions must be `noexcept`.
-- Most destructors are implicitly `noexcept` by default.
-- Also, [make move operations `noexcept`](#Rc-move-noexcept).
-- If writing a type intended to be used as an exception type, ensure its copy constructor is not `noexcept`. In general we cannot mechanically enforce this, because we do not know whether a type is intended to be used as an exception type.
-- Try not to `throw` a type whose copy constructor is not `noexcept`. In general we cannot mechanically enforce this, because even `throw std::string(...)` could throw but does not in practice.
+* Deallocation functions, including `operator delete`, must be `noexcept`.
+* `swap` functions must be `noexcept`.
+* Most destructors are implicitly `noexcept` by default.
+* Also, [make move operations `noexcept`](#Rc-move-noexcept).
+* If writing a type intended to be used as an exception type, ensure its copy constructor is not `noexcept`. In general we cannot mechanically enforce this, because we do not know whether a type is intended to be used as an exception type.
+* Try not to `throw` a type whose copy constructor is not `noexcept`. In general we cannot mechanically enforce this, because even `throw std::string(...)` could throw but does not in practice.
 
 ##### Enforcement
 
-- Catch destructors, deallocation operations, and `swap`s that `throw`.
-- Catch such operations that are not `noexcept`.
+* Catch destructors, deallocation operations, and `swap`s that `throw`.
+* Catch such operations that are not `noexcept`.
 
 **See also**: [discussion](#Sd-never-fail)
 


### PR DESCRIPTION
Addressed:
> 16132:1-16132:75   warning  Marker style should be `*`  unordered-list-marker-style
> 16133:1-16133:39   warning  Marker style should be `*`  unordered-list-marker-style
> 16134:1-16134:57   warning  Marker style should be `*`  unordered-list-marker-style
> 16135:1-16135:62   warning  Marker style should be `*`  unordered-list-marker-style
> 16136:1-16136:240  warning  Marker style should be `*`  unordered-list-marker-style
> 16137:1-16137:194  warning  Marker style should be `*`  unordered-list-marker-style
> 16141:1-16141:72   warning  Marker style should be `*`  unordered-list-marker-style
> 16142:1-16142:49   warning  Marker style should be `*`  unordered-list-marker-style