### PR TITLE
E.19: clarify that `finally` is from the GSL

### DIFF
--- a/CppCoreGuidelines.md
+++ b/CppCoreGuidelines.md
@@ -16216,14 +16216,14 @@ Better:
 
 ##### Reason
 
-`finally` is less verbose and harder to get wrong than `try`/`catch`.
+`finally` from the [GSL](#S-gsl) is less verbose and harder to get wrong than `try`/`catch`.
 
 ##### Example
 
     void f(int n)
     {
         void* p = malloc(n);
-        auto _ = finally([p] { free(p); });
+        auto _ = gsl::finally([p] { free(p); });
         // ...
     }
 


### PR DESCRIPTION
When I stumbled upon E.19 "Use a `final_action` object to express
cleanup if no suitable resource handle is available" I was hopeful
that this `final_action`/`finally()` thing is from the STL, but, alas,
it isn't.

Make it clear that `finally` is a GSL construct.