### PR TITLE
SF.5: prefer relative import to absolute one

### DIFF
--- a/CppCoreGuidelines.md
+++ b/CppCoreGuidelines.md
@@ -19263,7 +19263,7 @@ The errors will not be caught until link time for a program calling `bar` or `fo
     int foobar(int);
 
     // foo.cpp:
-    #include <foo.h>
+    #include "foo.h"
 
     void foo(int) { /* ... */ }
     int bar(double) { /* ... */ }


### PR DESCRIPTION
Applies change stated in issue #1943.

Signed-off-by: Daniel Kříž <Daniel.kriz@protonmail.com>