### PR TITLE
E.15 Clarify when a rethrow would slice to `std::exception`

### DIFF
--- a/CppCoreGuidelines.md
+++ b/CppCoreGuidelines.md
@@ -16093,7 +16093,7 @@ Catch by value can be appropriate for a small value type such as an `enum` value
 
 ##### Note
 
-To rethrow a caught exception use `throw;` not `throw e;`. Using `throw e;` would throw a new copy of `e` (sliced to the static type `std::exception`) instead of rethrowing the original exception of type `std::runtime_error`. (But keep [Don't try to catch every exception in every function](#Re-not-always) and [Minimize the use of explicit `try`/`catch`](#Re-catch) in mind.)
+To rethrow a caught exception use `throw;` not `throw e;`. Using `throw e;` would throw a new copy of `e` (sliced to the static type `std::exception`, when the exception is caught by `catch (const std::exception& e)`) instead of rethrowing the original exception of type `std::runtime_error`. (But keep [Don't try to catch every exception in every function](#Re-not-always) and [Minimize the use of explicit `try`/`catch`](#Re-catch) in mind.)
 
 ##### Enforcement
 


### PR DESCRIPTION
Avoided a potential misunderstanding that `throw e` would slice *any* `e` to `std::exception`.

The note about rethrowing appears to be written when the example of this item still did `catch (const exception& e)`, which was prior to commit d568d190f65a2cd9d3a3fde74cddbc5b5489bd99, "Generalized E.15, closes #1848".