### PR TITLE
R.5 (scoped objects): Remove `auto` from Enforcement section

### DIFF
--- a/CppCoreGuidelines.md
+++ b/CppCoreGuidelines.md
@@ -9548,7 +9548,7 @@ Instead, use a local variable:
 
 ##### Enforcement
 
-* (Moderate) Warn if an object is allocated and then deallocated on all paths within a function. Suggest it should be a local `auto` stack object instead.
+* (Moderate) Warn if an object is allocated and then deallocated on all paths within a function. Suggest it should be a local stack object instead.
 * (Simple) Warn if a local `Unique_pointer` or `Shared_pointer` is not moved, copied, reassigned or `reset` before its lifetime ends.
 
 ### <a name="Rr-global"></a>R.6: Avoid non-`const` global variables


### PR DESCRIPTION
The enforcement rule on "an object is allocated and then deallocated on all paths" is not _specifically_ about objects declared by the `auto` keyword, and `auto` does not just mean "automatic storage duration" anymore.