### PR TITLE
R.5 (scoped objects): Only warn if initialized by `new` or make

### DIFF
--- a/CppCoreGuidelines.md
+++ b/CppCoreGuidelines.md
@@ -9563,7 +9563,7 @@ Instead, use a local variable:
 ##### Enforcement
 
 * (Moderate) Warn if an object is allocated and then deallocated on all paths within a function. Suggest it should be a local stack object instead.
-* (Simple) Warn if a local `Unique_pointer` or `Shared_pointer` is not moved, copied, reassigned or `reset` before its lifetime ends.
+* (Moderate) Warn if a local `Unique_pointer` or `Shared_pointer` that is initialized by `new`, `make_unique`, `make_unique_for_overwrite`, `make_shared`, or `make_shared_for_overwrite` is not moved, copied, reassigned or `reset` before its lifetime ends.
 Exception: Do not produce such a warning on a local `Unique_pointer` to an unbounded array. (See below.)
 
 ##### Exception


### PR DESCRIPTION
The warning for a local smart pointer should only be produced when this smart pointer was initialized by `new`, or by one of the "make" functions like `make_unique`.

It is OK to initialize a local smart pointer by a "factory method", even when it is not moved, copied, reassigned or reset afterwards:

    void print_product_properties(std::string_view product_name)
    {
      // Local smart pointer initialized by a "factory method", OK.
      const std::unique_ptr<abstract_product> product = factory::create_product(product_name);
      std::cout << product->get_price() << ' ' << product->get_size() << '\n';
    }

Changed the enforcement rule from Simple to Moderate, because of this adjustment, as well as the exception that was added by pull request https://github.com/isocpp/CppCoreGuidelines/pull/1969 commit f4a9420e3225fa29034a4b1c911bdb1c1e61a45c.

----

Inspired by a comment by @Xeverous at https://github.com/isocpp/CppCoreGuidelines/pull/1969#issuecomment-1246811951