### PR TITLE
Fix typo reference to pro-type-union

### DIFF
--- a/CppCoreGuidelines.md
+++ b/CppCoreGuidelines.md
@@ -21082,7 +21082,7 @@ Prefer [construction](#Res-construct) or [named casts](#Res-casts-named) or `T{e
 [always initialize](#Res-always),
 possibly using [default constructors](#Rc-default0) or
 [default member initializers](#Rc-in-class-initializer).
-* <a name="Pro-type-unon"></a>Type.7: Avoid naked union:
+* <a name="Pro-type-union"></a>Type.7: Avoid naked union:
 [Use `variant` instead](#Ru-naked).
 * <a name="Pro-type-varargs"></a>Type.8: Avoid varargs:
 [Don't use `va_arg` arguments](#F-varargs).


### PR DESCRIPTION
clang-tidy has [cppcoreguidelines-pro-type-union-access](https://clang.llvm.org/extra/clang-tidy/checks/cppcoreguidelines/pro-type-union-access.html) that refers to the  pro-type-union. Unfortunately there's an typo. This commit tries to fix the type