### PR TITLE
Editorial - use "capture default"

### DIFF
--- a/CppCoreGuidelines.md
+++ b/CppCoreGuidelines.md
@@ -4132,7 +4132,7 @@ This is under active discussion in standardization, and might be addressed in a 
 
 ##### Enforcement
 
-* Flag any lambda capture-list that specifies a default capture and also captures `this` (whether explicitly or via default capture)
+* Flag any lambda capture-list that specifies a capture-default and also captures `this` (whether explicitly or via default capture)
 
 ### <a name="F-varargs"></a>F.55: Don't use `va_arg` arguments
 


### PR DESCRIPTION
Opening to get a question answered, along with a possible editorial fix. The standard document does not refer to "default capture," but always refers to "capture-default" (when referring to the language grammar). Is there a preferred way to say this? Would it be cleaner to stick to a single phrase, "capture default" as done in my PR here?

Note: [cppreference](https://en.cppreference.com/w/cpp/language/lambda) uses "capture default" or "capture-default" in all places, although I will add that I [*just* changed](https://en.cppreference.com/mwiki/index.php?title=cpp%2Flanguage%2Flambda&diff=146169&oldid=145543) the lone occurrence of "default capture" to be consistent with the other 15 references on this page.