### PR TITLE
Abstract class needs at least one abstract method to be considered abstract

### DIFF
--- a/CppCoreGuidelines.md
+++ b/CppCoreGuidelines.md
@@ -4938,6 +4938,7 @@ defined as defaulted.
 
     class AbstractBase {
     public:
+        virtual void foo() = 0;  // at least one abstract method to make the class abstract
         virtual ~AbstractBase() = default;
         // ...
     };


### PR DESCRIPTION
The introduction of the method is needed, for instance, for constructions like std::is_abstract<AbstractBase>::value to be evaluated to true.
Another option is to make the destructor pure virtual as well (=0), but that would defeat the purpose of the explanation of having a default destructor for the class.

See example in compiler explorer: https://godbolt.org/z/z1Y6nG93q