### PR TITLE
Clarify `using namespace` enforcement

### DIFF
--- a/CppCoreGuidelines.md
+++ b/CppCoreGuidelines.md
@@ -19408,7 +19408,7 @@ and M functions each containing a `using namespace X`with N lines of code in tot
 
 ##### Enforcement
 
-Flag multiple `using namespace` directives for different namespaces in a single source file.
+Flag multiple `using namespace` directives for different namespaces in the same scope.
 
 ### <a name="Rs-using-directive"></a>SF.7: Don't write `using namespace` at global scope in a header file
 


### PR DESCRIPTION
I feel like the original statement...

> **Enforcement** Flag multiple `using namespace` directives for different namespaces in a single source file.


...doesn't take into consideration that it can be okay to use multiple `using namespace` directives as long as they're in different scopes -- possibly within the same file.

I propose the following alternative, which may better target the real culprit...

> **Enforcement** Flag multiple `using namespace` directives for different namespaces in the same scope.