### PR TITLE
Use enum class in Enum.4 example.

### DIFF
--- a/CppCoreGuidelines.md
+++ b/CppCoreGuidelines.md
@@ -9150,7 +9150,7 @@ Convenience of use and avoidance of errors.
 
 ##### Example
 
-    enum Day { mon, tue, wed, thu, fri, sat, sun };
+    enum class Day { mon, tue, wed, thu, fri, sat, sun };
 
     Day& operator++(Day& d)
     {


### PR DESCRIPTION
Minor code change in Enum.4's example using a class enum over a "plain" enum as per Enum.3.