### PR TITLE
Fix missing forward for function object parameter

### DIFF
--- a/CppCoreGuidelines.md
+++ b/CppCoreGuidelines.md
@@ -3142,9 +3142,9 @@ In that case, and only that case, make the parameter `TP&&` where `TP` is a temp
 Usually you forward the entire parameter (or parameter pack, using `...`) exactly once on every static control flow path:
 
     template<class F, class... Args>
-    inline auto invoke(F f, Args&&... args)
+    inline decltype(auto) invoke(F&& f, Args&&... args)
     {
-        return f(forward<Args>(args)...);
+        return forward<F>(f)(forward<Args>(args)...);
     }
 
 ##### Example


### PR DESCRIPTION
The function:
```cpp
template<class F, class... Args>
inline auto invoke(F f, Args&&... args)
{
    return f(forward<Args>(args)...);
}
```
should have a forwarded parameter `F`, because it is demonstrates the example prose much better, and is also "more correct".

> Usually you forward the entire parameter (or parameter pack, using `...`) exactly once on every static control flow path

`f` is being used exactly once in this function, so it only makes sense to use perfect forwarding here, and to `forward` it when it is called. Forwarding function objects has the benefit that any rvalue overloads of the call operator are going to be called.

Furthermore, using `auto` as a return type seems wrong, because it results in unnecessary copies if `f` returns an lvalue-reference, and unnecessary moves if `f` returns an rvalue-reference. If `f` returns a reference, so should the `invoke` wrapper.

You can find a very similar function the one I have suggested at [`std::apply` on cppreference](https://en.cppreference.com/w/cpp/utility/apply)