### PR TITLE
fix memory leak in example of C.66

### DIFF
--- a/CppCoreGuidelines.md
+++ b/CppCoreGuidelines.md
@@ -6436,8 +6436,13 @@ A non-throwing move will be used more efficiently by standard-library and langua
     template<typename T>
     class Vector {
     public:
-        Vector(Vector&& a) noexcept :elem{a.elem}, sz{a.sz} { a.sz = 0; a.elem = nullptr; }
-        Vector& operator=(Vector&& a) noexcept { elem = a.elem; sz = a.sz; a.sz = 0; a.elem = nullptr; }
+        Vector(Vector&& a) noexcept :elem{a.elem}, sz{a.sz} { a.elem = nullptr; a.sz = 0; }
+        Vector& operator=(Vector&& a) noexcept {
+            delete elem;
+            elem = a.elem; a.elem = nullptr;
+            sz   = a.sz;   a.sz   = 0;
+            return *this;
+        }
         // ...
     private:
         T* elem;


### PR DESCRIPTION
This PR fixes multiple issues with the example code:

- The previous example was leaking the resource `elem`, which is presumably heap-allocated. While correct resource-management is not subject of this example, it is still a bug which shouldn't be included.
- In the move constructor, the members `a.sz` and `a.elem` were assigned in the opposite order in which they are declared. This is not incorrect, just annoying.
- The move assignment operator failed to `return *this;`, leading to undefined behavior. No indication was made that code was missing, e.g. using `/* ... */`.