### PR TITLE
Improve reasoning and examples for F.48

### DIFF
--- a/CppCoreGuidelines.md
+++ b/CppCoreGuidelines.md
@@ -3922,7 +3922,9 @@ value) of any assignment operator.
 
 ##### Reason
 
-With guaranteed copy elision, it is now almost always a pessimization to expressly use `std::move` in a return statement.
+Returning a local variable implicitly moves it anyway.
+An explicit `std::move` is also a pessimization, because it prevents Named Return Value Optimization (NRVO),
+which can eliminate the move completely. 
 
 ##### Example, bad
 

--- a/CppCoreGuidelines.md
+++ b/CppCoreGuidelines.md
@@ -3936,10 +3936,7 @@ which can eliminate the move completely.
 
 ##### Example, good
 
-    // RVO: guaranteed move elision when a temporary is returned
-    S rvo() { return S{}; }
-
-    S nrvo()
+    S good()
     {
       S result;
       // Named RVO: move elision at best, move construction at worst

--- a/CppCoreGuidelines.md
+++ b/CppCoreGuidelines.md
@@ -3923,12 +3923,12 @@ value) of any assignment operator.
 ##### Reason
 
 Returning a local variable implicitly moves it anyway.
-An explicit `std::move` is also a pessimization, because it prevents Named Return Value Optimization (NRVO),
+An explicit `std::move` is always a pessimization, because it prevents Return Value Optimization (RVO),
 which can eliminate the move completely. 
 
 ##### Example, bad
 
-    S f()
+    S bad()
     {
       S result;
       return std::move(result);
@@ -3936,9 +3936,13 @@ which can eliminate the move completely.
 
 ##### Example, good
 
-    S f()
+    // RVO: guaranteed move elision when a temporary is returned
+    S rvo() { return S{}; }
+
+    S nrvo()
     {
       S result;
+      // Named RVO: move elision at best, move construction at worst
       return result;
     }
 


### PR DESCRIPTION
> With guaranteed copy elision, it is now almost always a pessimization to expressly use `std::move` in a return statement.

The reasoning in **F.48** is misleading because it only refers to *guaranteed* copy elision, but the example listed underneath shows NRVO, for which this elision is *not guaranteed*.

I think it the reasoning is much better if it is made clear to the reader that a return statement will always move local variables. It is also helpful to distinguish between RVO and NRVO in the example, as the two have optimization differences.