### PR TITLE
Fix ill-formed example C.65 (missing noexcept on declaration)

### DIFF
--- a/CppCoreGuidelines.md
+++ b/CppCoreGuidelines.md
@@ -6387,7 +6387,7 @@ If `x = x` changes the value of `x`, people will be surprised and bad errors can
         string s;
         int i;
     public:
-        Foo& operator=(Foo&& a);
+        Foo& operator=(Foo&& a) noexcept;
         // ...
     };
 


### PR DESCRIPTION
There cannot be a mismatch between the exception specification of a declaration and definition. The example in its current form fails to compile.