### PR TITLE
 use the "is" variable in ES.34

### DIFF
--- a/CppCoreGuidelines.md
+++ b/CppCoreGuidelines.md
@@ -11491,7 +11491,7 @@ Requires messy cast-and-macro-laden code to get working right.
         error(7, "this", "is", "an", "error");  // crash
         const char* is = "is";
         string an = "an";
-        error(7, "this", "is", an, "error"); // crash
+        error(7, "this", is, an, "error"); // crash
     }
 
 **Alternative**: Overloading. Templates. Variadic templates.


### PR DESCRIPTION
why not use the "const char * is" previously declared (even if it is the bad example)?