### PR TITLE
NL.8: elaborate on reserved identifiers

### DIFF
--- a/CppCoreGuidelines.md
+++ b/CppCoreGuidelines.md
@@ -21594,8 +21594,8 @@ ISO Standard, use lower case only and digits, separate words with underscores:
 * `vector`
 * `my_map`
 
-Avoid identifiers containing double underscores `__` and names with leading underscores.
-They are (almost) always reserved identifiers.
+Avoid identifiers containing double underscores `__` and names that start with an underscore followed by a capital letter (e.g., `_Throws`).
+Such identifiers are reserved for the C++ implementation.
 
 ##### Example
 

--- a/CppCoreGuidelines.md
+++ b/CppCoreGuidelines.md
@@ -21594,7 +21594,7 @@ ISO Standard, use lower case only and digits, separate words with underscores:
 * `vector`
 * `my_map`
 
-Avoid identifiers containing double underscores `__` and names that start with an underscore followed by a capital letter (e.g., `_Throws`).
+Avoid identifier names that contain double underscores `__` or that start with an underscore followed by a capital letter (e.g., `_Throws`).
 Such identifiers are reserved for the C++ implementation.
 
 ##### Example

--- a/CppCoreGuidelines.md
+++ b/CppCoreGuidelines.md
@@ -21594,7 +21594,7 @@ ISO Standard, use lower case only and digits, separate words with underscores:
 * `vector`
 * `my_map`
 
-Avoid identifiers containing underscores `__` and names with leading underscores.
+Avoid identifiers containing double underscores `__` and names with leading underscores.
 They are (almost) always reserved identifiers.
 
 ##### Example

--- a/CppCoreGuidelines.md
+++ b/CppCoreGuidelines.md
@@ -21594,7 +21594,8 @@ ISO Standard, use lower case only and digits, separate words with underscores:
 * `vector`
 * `my_map`
 
-Avoid double underscores `__`.
+Avoid identifiers containing underscores `__` and names with leading underscores.
+They are (almost) always reserved identifiers.
 
 ##### Example
 


### PR DESCRIPTION
I feel like the current suggestion just reads like a stylistic recommendation.

In reality, your code might fail to compile, or it could be IFNDR if you use one of those reserved names. There should be at least a little bit of rationale, and leading underscores should also be banned.

Technically, leading underscores aren't always reserved, but it's difficult to memorize all the rules, and it's easy to be safe by just banning them.