### PR TITLE
ES.30 fix example code

### DIFF
--- a/CppCoreGuidelines.md
+++ b/CppCoreGuidelines.md
@@ -11378,8 +11378,8 @@ There are workarounds for low-level string manipulation using macros. For exampl
 
     void f()
     {
-        string s1 = stringify<1>(); //ok
-        string s2 = stringify<2>(); //does not compile
+        string s1 = stringify<a>();
+        string s2 = stringify<b>();
         // ...
     }
 

--- a/CppCoreGuidelines.md
+++ b/CppCoreGuidelines.md
@@ -11365,8 +11365,6 @@ Also, `#` and `##` encourages the definition and use of macros:
 
 There are workarounds for low-level string manipulation using macros. For example:
 
-    string s = "asdf" "lkjh";   // ordinary string literal concatenation
-
     enum E { a, b };
 
     template<int x>
@@ -11378,9 +11376,10 @@ There are workarounds for low-level string manipulation using macros. For exampl
         }
     }
 
-    void f(int x, int y)
+    void f()
     {
-        string sx = stringify<x>();
+        string s1 = stringify<1>(); //ok
+        string s2 = stringify<2>(); //does not compile
         // ...
     }
 


### PR DESCRIPTION
The example should be passing in a constexpr and validating it at compile time like a macro, but instead passes a unknown value at compile time. Which may cause mislead and the code doesn't even work.

Ref: #2136