### PR TITLE
[easy] Fix DeprecationWarning for cgi package

### DIFF
--- a/scripts/python/md-split.py
+++ b/scripts/python/md-split.py
@@ -10,7 +10,7 @@ import shutil
 import io
 import argparse
 
-import re, cgi
+import re
 TAG_REGEX = re.compile(r'(<!--.*?-->|<[^>]*>)')
 NAMED_A_TAG_REGEX = re.compile(r'.*name ?= ?"([^"]*)"')
 


### PR DESCRIPTION
I just tried building the core guidelines for the first time, and got a `DeprecationWarning`.

```
./python/md-split.py:13: DeprecationWarning: 'cgi' is deprecated and slated for removal in Python 3.13
  import re, cgi
```

This package is imported but seems completely unused in the script. This removes the import.

EDIT: I do not have commit access, please accept and ship.