### PR TITLE
Use portable header identifiers

### DIFF
--- a/CppCoreGuidelines.md
+++ b/CppCoreGuidelines.md
@@ -19654,7 +19654,7 @@ To maximize the portability of `#include` directives across compilers, guidance 
     #include <VECTOR>             // the standard library defines a header identified as <vector>, not <VECTOR>
     #include <String>             // the standard library defines a header identified as <string>, not <String>
     #include "foo_utils\utils.h"  // may not work if `\u` is interpreted as an escape sequence, or on a system where `\` is not a valid path separator
-    #include "Foo_Utils/Utils.H"  // the header file as it exists on the file system is "foo_utils/utils.h"
+    #include "Foo_Utils/Utils.H"  // the header file exists on the file system as `"foo_utils/utils.h"`
 
 ##### Enforcement
 

--- a/CppCoreGuidelines.md
+++ b/CppCoreGuidelines.md
@@ -19648,12 +19648,13 @@ To maximize the portability of `#include` directives across compilers, guidance 
     // good examples
     #include <vector>
     #include <string>
-    #include "utils/utils.h"
+    #include "foo_utils/utils.h"
     
     // bad examples
     // #include <VECTOR>             // the standard library defines a header identified as <vector>, not <VECTOR>
     // #include <String>             // the standard library defines a header identified as <string>, not <String>
-    // #include "utils\utils.h"      // may not work if `\u` is interpreted as an escape sequence, or on a system where `\` is not a valid path separator
+    // #include "foo_utils\utils.h"  // may not work if `\u` is interpreted as an escape sequence, or on a system where `\` is not a valid path separator
+    // #include "Foo_Utils/Utils.H"  // the header file as it exists on the file system is "foo_utils/utils.h"
 
 ##### Enforcement
 

--- a/CppCoreGuidelines.md
+++ b/CppCoreGuidelines.md
@@ -19636,12 +19636,12 @@ A test should identify whether headers referenced via `""` could be referenced w
 
 ##### Reason
 
-The [standard](http://eel.is/c++draft/cpp.include) does not specify how compilers locate headers from a unique identifier in a `#include` directive, nor does it specify what constitutes uniqueness for an identifier. For example, whether the implementation considers the identifiers to be case-sensitive, or whether the identifiers are file system paths to a header file, and if so, how a hierarchical file system path is delimited.
+The [standard](http://eel.is/c++draft/cpp.include) does not specify how compilers uniquely locate headers from an identifier in an `#include` directive, nor does it specify what constitutes uniqueness. For example, whether the implementation considers the identifiers to be case-sensitive, or whether the identifiers are file system paths to a header file, and if so, how a hierarchical file system path is delimited.
 
 To maximize the portability of `#include` directives across compilers, guidance is to:
 
-* use case-sensitivity for the header identifier, matching how the header is defined by the standard, specification, implementation, header file, etc.
-* when the header identifier is a hierarchical file system path, use forward-slash `/` to delimit path components  as this is the most widely-accepted, portable path-delimiting character.
+* use case-sensitivity for the header identifier, matching how the header is defined by the standard, specification, implementation, or file that provides the header.
+* when the header identifier is a hierarchical file path, use forward-slash `/` to delimit path components as this is the most widely-accepted path-delimiting character.
 
 ##### Example
 

--- a/CppCoreGuidelines.md
+++ b/CppCoreGuidelines.md
@@ -19619,7 +19619,7 @@ Nevertheless, the guidance is to use the quoted form for including files that ex
     #include <string>                // From the standard library, requires the <> form
     #include <some_library/common.h> // A file that is not locally relative, included from another library; use the <> form
     #include "foo.h"                 // A file locally relative to foo.cpp in the same project, use the "" form
-    #include "foo_utils/utils.h"     // A file locally relative to foo.cpp in the same project, use the "" form
+    #include "util/util.h"           // A file locally relative to foo.cpp in the same project, use the "" form
     #include <component_b/bar.h>     // A file in the same project located via a search path, use the <> form
 
 ##### Note
@@ -19648,13 +19648,13 @@ To maximize the portability of `#include` directives across compilers, guidance 
     // good examples
     #include <vector>
     #include <string>
-    #include "foo_utils/utils.h"
+    #include "util/util.h"
     
     // bad examples
-    #include <VECTOR>             // the standard library defines a header identified as <vector>, not <VECTOR>
-    #include <String>             // the standard library defines a header identified as <string>, not <String>
-    #include "Foo_Utils/Utils.H"  // the header file exists on the file system as "foo_utils/utils.h"
-    #include "foo_utils\utils.h"  // may not work if `\u` is interpreted as an escape sequence, or on a system where '\' is not a valid path separator
+    #include <VECTOR>        // the standard library defines a header identified as <vector>, not <VECTOR>
+    #include <String>        // the standard library defines a header identified as <string>, not <String>
+    #include "Util/Util.H"   // the header file exists on the file system as "util/util.h"
+    #include "util\util.h"   // may not work if the implementation interprets `\u` as an escape sequence, or where '\' is not a valid path separator
 
 ##### Enforcement
 

--- a/CppCoreGuidelines.md
+++ b/CppCoreGuidelines.md
@@ -19208,6 +19208,7 @@ Source file rule summary:
 * [SF.10: Avoid dependencies on implicitly `#include`d names](#Rs-implicit)
 * [SF.11: Header files should be self-contained](#Rs-contained)
 * [SF.12: Prefer the quoted form of `#include` for files relative to the including file and the angle bracket form everywhere else](#Rs-incform)
+* [SF.13: Use portable header identifiers in `#include` statements](#Rs-include-casing)
 
 * [SF.20: Use `namespace`s to express logical structure](#Rs-namespace)
 * [SF.21: Don't use an unnamed (anonymous) namespace in a header](#Rs-unnamed)
@@ -19630,6 +19631,32 @@ Library creators should put their headers in a folder and have clients include t
 ##### Enforcement
 
 A test should identify whether headers referenced via `""` could be referenced with `<>`.
+
+### <a name="Rs-include-identifier"></a>SF.13: Use portable header identifiers in `#include` statements
+
+##### Reason
+
+The [standard](http://eel.is/c++draft/cpp.include) does not specifiy how compilers locate headers from a unique identifier in a '#include' directive, nor does it specify what constitutes uniqueness for an identifier. For example, whether the implementation considers the identifiers to be case-sensitive, or whether the identifiers are file system paths to a header file, and if so, how a hierarchical file system path is delimited.
+
+To maximize the portability of `#include` directives across compilers, guidance is to:
+- use case-sensitivity for the header identifier, matching how the header is defined by the standard, specification, implementation, header file, etc.
+- when the header identifier is a hierarchical file system path, use forward-slash '/' to delimit path components  as this is the most widely-accepted, portable path-delimiting character.
+
+##### Example
+
+    // good examples
+    #include <vector>
+    #include <string>
+    #include "utils/utils.h"
+    
+    // bad examples
+    // #include <VECTOR>             // the standard library defines a header identified as <vector>, not <VECTOR>
+    // #include <String>             // the standard library defines a header identified as <string>, not <String>
+    // #include "utils\utils.h"      // may not work if '\u' is interpreted as an escape sequence, or on a system where '\' is not a valid path separator
+
+##### Enforcement
+
+It is only possible to enforce on implementations where header identifiers are case-sensitive and which only support '/' as a file path delimiter.
 
 ### <a name="Rs-namespace"></a>SF.20: Use `namespace`s to express logical structure
 

--- a/CppCoreGuidelines.md
+++ b/CppCoreGuidelines.md
@@ -19651,10 +19651,10 @@ To maximize the portability of `#include` directives across compilers, guidance 
     #include "util/util.h"
     
     // bad examples
-    #include <VECTOR>        // the standard library defines a header identified as <vector>, not <VECTOR>
-    #include <String>        // the standard library defines a header identified as <string>, not <String>
-    #include "Util/Util.H"   // the header file exists on the file system as "util/util.h"
-    #include "util\util.h"   // may not work if the implementation interprets `\u` as an escape sequence, or where '\' is not a valid path separator
+    #include <VECTOR>        // bad: the standard library defines a header identified as <vector>, not <VECTOR>
+    #include <String>        // bad: the standard library defines a header identified as <string>, not <String>
+    #include "Util/Util.H"   // bad: the header file exists on the file system as "util/util.h"
+    #include "util\util.h"   // bad: may not work if the implementation interprets `\u` as an escape sequence, or where '\' is not a valid path separator
 
 ##### Enforcement
 

--- a/CppCoreGuidelines.md
+++ b/CppCoreGuidelines.md
@@ -19208,7 +19208,7 @@ Source file rule summary:
 * [SF.10: Avoid dependencies on implicitly `#include`d names](#Rs-implicit)
 * [SF.11: Header files should be self-contained](#Rs-contained)
 * [SF.12: Prefer the quoted form of `#include` for files relative to the including file and the angle bracket form everywhere else](#Rs-incform)
-* [SF.13: Use portable header identifiers in `#include` statements](#Rs-portable-headerid)
+* [SF.13: Use portable header identifiers in `#include` statements](#Rs-portable-header-id)
 
 * [SF.20: Use `namespace`s to express logical structure](#Rs-namespace)
 * [SF.21: Don't use an unnamed (anonymous) namespace in a header](#Rs-unnamed)
@@ -19632,15 +19632,16 @@ Library creators should put their headers in a folder and have clients include t
 
 A test should identify whether headers referenced via `""` could be referenced with `<>`.
 
-### <a name="Rs-portable-headerid"></a>SF.13: Use portable header identifiers in `#include` statements
+### <a name="Rs-portable-header-id"></a>SF.13: Use portable header identifiers in `#include` statements
 
 ##### Reason
 
-The [standard](http://eel.is/c++draft/cpp.include) does not specifiy how compilers locate headers from a unique identifier in a '#include' directive, nor does it specify what constitutes uniqueness for an identifier. For example, whether the implementation considers the identifiers to be case-sensitive, or whether the identifiers are file system paths to a header file, and if so, how a hierarchical file system path is delimited.
+The [standard](http://eel.is/c++draft/cpp.include) does not specify how compilers locate headers from a unique identifier in a `#include` directive, nor does it specify what constitutes uniqueness for an identifier. For example, whether the implementation considers the identifiers to be case-sensitive, or whether the identifiers are file system paths to a header file, and if so, how a hierarchical file system path is delimited.
 
 To maximize the portability of `#include` directives across compilers, guidance is to:
-- use case-sensitivity for the header identifier, matching how the header is defined by the standard, specification, implementation, header file, etc.
-- when the header identifier is a hierarchical file system path, use forward-slash '/' to delimit path components  as this is the most widely-accepted, portable path-delimiting character.
+
+* use case-sensitivity for the header identifier, matching how the header is defined by the standard, specification, implementation, header file, etc.
+* when the header identifier is a hierarchical file system path, use forward-slash `/` to delimit path components  as this is the most widely-accepted, portable path-delimiting character.
 
 ##### Example
 
@@ -19652,11 +19653,11 @@ To maximize the portability of `#include` directives across compilers, guidance 
     // bad examples
     // #include <VECTOR>             // the standard library defines a header identified as <vector>, not <VECTOR>
     // #include <String>             // the standard library defines a header identified as <string>, not <String>
-    // #include "utils\utils.h"      // may not work if '\u' is interpreted as an escape sequence, or on a system where '\' is not a valid path separator
+    // #include "utils\utils.h"      // may not work if `\u` is interpreted as an escape sequence, or on a system where `\` is not a valid path separator
 
 ##### Enforcement
 
-It is only possible to enforce on implementations where header identifiers are case-sensitive and which only support '/' as a file path delimiter.
+It is only possible to enforce on implementations where header identifiers are case-sensitive and which only support `/` as a file path delimiter.
 
 ### <a name="Rs-namespace"></a>SF.20: Use `namespace`s to express logical structure
 

--- a/CppCoreGuidelines.md
+++ b/CppCoreGuidelines.md
@@ -19208,7 +19208,7 @@ Source file rule summary:
 * [SF.10: Avoid dependencies on implicitly `#include`d names](#Rs-implicit)
 * [SF.11: Header files should be self-contained](#Rs-contained)
 * [SF.12: Prefer the quoted form of `#include` for files relative to the including file and the angle bracket form everywhere else](#Rs-incform)
-* [SF.13: Use portable header identifiers in `#include` statements](#Rs-include-casing)
+* [SF.13: Use portable header identifiers in `#include` statements](#Rs-portable-headerid)
 
 * [SF.20: Use `namespace`s to express logical structure](#Rs-namespace)
 * [SF.21: Don't use an unnamed (anonymous) namespace in a header](#Rs-unnamed)
@@ -19632,7 +19632,7 @@ Library creators should put their headers in a folder and have clients include t
 
 A test should identify whether headers referenced via `""` could be referenced with `<>`.
 
-### <a name="Rs-include-identifier"></a>SF.13: Use portable header identifiers in `#include` statements
+### <a name="Rs-portable-headerid"></a>SF.13: Use portable header identifiers in `#include` statements
 
 ##### Reason
 

--- a/CppCoreGuidelines.md
+++ b/CppCoreGuidelines.md
@@ -19651,10 +19651,10 @@ To maximize the portability of `#include` directives across compilers, guidance 
     #include "foo_utils/utils.h"
     
     // bad examples
-    // #include <VECTOR>             // the standard library defines a header identified as <vector>, not <VECTOR>
-    // #include <String>             // the standard library defines a header identified as <string>, not <String>
-    // #include "foo_utils\utils.h"  // may not work if `\u` is interpreted as an escape sequence, or on a system where `\` is not a valid path separator
-    // #include "Foo_Utils/Utils.H"  // the header file as it exists on the file system is "foo_utils/utils.h"
+    #include <VECTOR>             // the standard library defines a header identified as <vector>, not <VECTOR>
+    #include <String>             // the standard library defines a header identified as <string>, not <String>
+    #include "foo_utils\utils.h"  // may not work if `\u` is interpreted as an escape sequence, or on a system where `\` is not a valid path separator
+    #include "Foo_Utils/Utils.H"  // the header file as it exists on the file system is "foo_utils/utils.h"
 
 ##### Enforcement
 

--- a/CppCoreGuidelines.md
+++ b/CppCoreGuidelines.md
@@ -19653,8 +19653,8 @@ To maximize the portability of `#include` directives across compilers, guidance 
     // bad examples
     #include <VECTOR>             // the standard library defines a header identified as <vector>, not <VECTOR>
     #include <String>             // the standard library defines a header identified as <string>, not <String>
-    #include "foo_utils\utils.h"  // may not work if `\u` is interpreted as an escape sequence, or on a system where `\` is not a valid path separator
-    #include "Foo_Utils/Utils.H"  // the header file exists on the file system as `"foo_utils/utils.h"`
+    #include "Foo_Utils/Utils.H"  // the header file exists on the file system as "foo_utils/utils.h"
+    #include "foo_utils\utils.h"  // may not work if `\u` is interpreted as an escape sequence, or on a system where '\' is not a valid path separator
 
 ##### Enforcement
 


### PR DESCRIPTION
add a new rule governing how to compose portable header path identifiers such that they respect proper casing (\<vector\>, not \<VECTOR\>) and portable path separators ('/' and not '\\')
