### PR TITLE
ES.23: change example code to better match the rule

### DIFF
--- a/CppCoreGuidelines.md
+++ b/CppCoreGuidelines.md
@@ -11093,7 +11093,8 @@ For containers, there is a tradition for using `{...}` for a list of elements an
 
     int x {7.9};   // error: narrowing
     int y = 7.9;   // OK: y becomes 7. Hope for a compiler warning
-    int z = gsl::narrow_cast<int>(7.9);  // OK: you asked for it
+    int z {gsl::narrow_cast<int>(7.9)};    // OK: you asked for it
+    auto zz = gsl::narrow_cast<int>(7.9);  // OK: you asked for it
 
 ##### Note
 


### PR DESCRIPTION
The example suggests that `int z = gsl::narrow_cast<int>(7.9);;` is OK. The rule says "Use `=` only when you are sure that there can be no narrowing conversions.", which matches, but is also says "For built-in arithmetic types, use `=` only with `auto`.", and this is not respected here. So replace the one line with both possibilities suggested by the rule.
