### PR TITLE
Make example code adhere to C.65

### DIFF
--- a/CppCoreGuidelines.md
+++ b/CppCoreGuidelines.md
@@ -6438,9 +6438,11 @@ A non-throwing move will be used more efficiently by standard-library and langua
     public:
         Vector(Vector&& a) noexcept :elem{a.elem}, sz{a.sz} { a.elem = nullptr; a.sz = 0; }
         Vector& operator=(Vector&& a) noexcept {
-            delete elem;
-            elem = a.elem; a.elem = nullptr;
-            sz   = a.sz;   a.sz   = 0;
+            if (&a != this) {
+                delete elem;
+                elem = a.elem; a.elem = nullptr;
+                sz   = a.sz;   a.sz   = 0;
+            }
             return *this;
         }
         // ...


### PR DESCRIPTION
C.65 requires move assignment to be safe for self-assignment. The given example is not safe for self-assignment as given right now. This commit fixes this.
