### PR TITLE
F.21 Don't return tuples

### DIFF
--- a/CppCoreGuidelines.md
+++ b/CppCoreGuidelines.md
@@ -3304,7 +3304,7 @@ To compare, if we passed out all values as return values, we would something lik
         return { in, move(s) };
     }
 
-    for (auto [in, s] = get_string(cin); in; s = get_string(stream).s) {
+    for (auto [in, s] = get_string(cin); in; s = get_string(in).s) {
         // do something with string
     }
 

--- a/CppCoreGuidelines.md
+++ b/CppCoreGuidelines.md
@@ -3250,7 +3250,7 @@ Otherwise, a `tuple` is useful in variadic templates.
 
     // GOOD: self-documenting
     struct f_result { int status; string data; };
-    
+
     f_result f(const string& input)
     {
         // ...
@@ -3618,8 +3618,8 @@ Using `std::shared_ptr` is the standard way to represent shared ownership. That 
         std::thread t2 {shade, args2, bottom_left, im};
         std::thread t3 {shade, args3, bottom_right, im};
 
-        // detaching threads requires extra care (e.g., to join
-        // before main ends), but even if we do detach t0..3 here ...
+        // detaching threads requires extra care (e.g., to join before
+        // main ends), but even if we do detach the four threads here ...
     }
     // ... shared_ptr ensures that eventually the last thread to
     //     finish safely deletes the image

--- a/CppCoreGuidelines.md
+++ b/CppCoreGuidelines.md
@@ -3257,7 +3257,7 @@ Otherwise, a `tuple` is useful in variadic templates.
         return {status, something()};
     }
 
-C++98's standard library somewhat used this style by returning `pair` in some functions.
+C++98's standard library used this style in places, by returning `pair` in some functions.
 For example, given a `set<string> my_set`, consider:
 
     // C++98

--- a/CppCoreGuidelines.md
+++ b/CppCoreGuidelines.md
@@ -3316,6 +3316,26 @@ However, we prefer to be explicit, rather than subtle.
 
 ##### Note
 
+In most cases, it is useful to return a specific, user-defined type.
+For example:
+
+    struct Distance {
+        int value;
+        int unit = 1;   // 1 means meters
+    };
+
+    Distance d1 = measure(obj1);        // access d1.value and d1.unit
+    auto d2 = measure(obj2);            // access d2.value and d2.unit
+    auto [value, unit] = measure(obj3); // access value and unit; somewhat redundant
+                                        // to people who know measure()
+    auto [x, y] = measure(obj4);        // don't; it's likely to be confusing
+
+The overly generic `pair` and `tuple` should be used only when the value returned represents independent entities rather than an abstraction.
+
+Another option is to use `optional<T>` or `expected<T, error_code>`, rather than `pair` or `tuple`.
+
+##### Note
+
 When the object to be returned is initialized from local variables that are expensive to copy,
 explicit `move` may be helpful to avoid copying:
 
@@ -3336,25 +3356,6 @@ Alternatively,
     }
 
 Note this is different from the `return move(...)` anti-pattern from [ES.56](#Res-move)
-
-##### Note
-
-For `struct`s where one member represents the success of an operation, adding an explicit conversion to `bool` is helpful:
-
-    struct parse_result {
-        bool success;
-        int value;
-        explicit operator bool() const { return success; }
-    };
-
-    parse_result parse_int(string_view s) { /* ... */ }
-
-    void f()
-    {
-        if (parse_result result = parse_int("123")) { use(result.value); }
-    }
-
-In most cases, C++17 `optional` and C++23 `expected` can replace this pattern.
 
 ##### Enforcement
 

--- a/CppCoreGuidelines.md
+++ b/CppCoreGuidelines.md
@@ -3293,7 +3293,7 @@ By reusing `s` (passed by reference), we allocate new memory only when we need t
 This technique is sometimes called the "caller-allocated out" pattern and is particularly useful for types,
 such as `string` and `vector`, that needs to do free store allocations.
 
-To compare, if we passed out all values as return values, we would something like this:
+To compare, if we passed out all values as return values, we would write something like this:
 
     struct get_string_result { istream& in; string s; };
 

--- a/CppCoreGuidelines.md
+++ b/CppCoreGuidelines.md
@@ -2358,7 +2358,7 @@ Parameter passing expression rules:
 * [F.18: For "will-move-from" parameters, pass by `X&&` and `std::move` the parameter](#Rf-consume)
 * [F.19: For "forward" parameters, pass by `TP&&` and only `std::forward` the parameter](#Rf-forward)
 * [F.20: For "out" output values, prefer return values to output parameters](#Rf-out)
-* [F.21: To return multiple "out" values, prefer returning a struct or tuple](#Rf-out-multi)
+* [F.21: To return multiple "out" values, prefer returning a struct](#Rf-out-multi)
 * [F.60: Prefer `T*` over `T&` when "no argument" is a valid option](#Rf-ptr-ref)
 
 Parameter passing semantic rules:
@@ -3228,13 +3228,15 @@ The return value optimization doesn't handle the assignment case, but the move a
 
 * Flag reference to non-`const` parameters that are not read before being written to and are a type that could be cheaply returned; they should be "out" return values.
 
-### <a name="Rf-out-multi"></a>F.21: To return multiple "out" values, prefer returning a struct or tuple
+### <a name="Rf-out-multi"></a>F.21: To return multiple "out" values, prefer returning a struct
 
 ##### Reason
 
 A return value is self-documenting as an "output-only" value.
-Note that C++ does have multiple return values, by convention of using a `tuple` (including `pair`), possibly with the extra convenience of `tie` or structured bindings (C++17) at the call site.
-Prefer using a named struct where there are semantics to the returned value. Otherwise, a nameless `tuple` is useful in generic code.
+Note that C++ does have multiple return values, by convention of using tuple-like types (`struct`, `array`, `tuple`, etc.),
+possibly with the extra convenience of structured bindings (C++17) at the call site.
+Prefer using a named `struct` if possible.
+Otherwise, a `tuple` is useful in variadic templates.
 
 ##### Example
 
@@ -3247,30 +3249,29 @@ Prefer using a named struct where there are semantics to the returned value. Oth
     }
 
     // GOOD: self-documenting
-    tuple<int, string> f(const string& input)
+    struct f_result { int status; string data; };
+    
+    f_result f(const string& input)
     {
         // ...
         return {status, something()};
     }
 
-C++98's standard library already used this style, because a `pair` is like a two-element `tuple`.
+C++98's standard library somewhat used this style by returning `pair` in some functions.
 For example, given a `set<string> my_set`, consider:
 
     // C++98
-    result = my_set.insert("Hello");
-    if (result.second) do_something_with(result.first);    // workaround
+    pair<set::iterator, bool> result = my_set.insert("Hello");
+    if (result.second)
+        do_something_with(result.first);    // workaround
 
-With C++11 we can write this, putting the results directly in existing local variables:
+With C++17 we are able to use "structured bindings" to give each member a name:
 
-    Sometype iter;                                // default initialize if we haven't already
-    Someothertype success;                        // used these variables for some other purpose
+    if (auto [ iter, success ] = my_set.insert("Hello"); success)
+        do_something_with(iter);
 
-    tie(iter, success) = my_set.insert("Hello");   // normal return value
-    if (success) do_something_with(iter);
-
-With C++17 we are able to use "structured bindings" to declare and initialize the multiple variables:
-
-    if (auto [ iter, success ] = my_set.insert("Hello"); success) do_something_with(iter);
+A `struct` with meaningful names is more common in modern C++.
+See for example `ranges::min_max_result`, `from_chars_result`, and others.
 
 ##### Exception
 
@@ -3294,15 +3295,17 @@ such as `string` and `vector`, that needs to do free store allocations.
 
 To compare, if we passed out all values as return values, we would something like this:
 
-    pair<istream&, string> get_string(istream& in)  // not recommended
+    struct get_string_result { istream& in; string s; };
+
+    get_string_result get_string(istream& in)  // not recommended
     {
         string s;
         in >> s;
-        return {in, move(s)};
+        return { in, move(s) };
     }
 
-    for (auto p = get_string(cin); p.first; p.second = get_string(p.first).second) {
-        // do something with p.second
+    for (auto [in, s] = get_string(cin); in; s = get_string(stream).s) {
+        // do something with string
     }
 
 We consider that significantly less elegant with significantly less performance.
@@ -3313,27 +3316,7 @@ However, we prefer to be explicit, rather than subtle.
 
 ##### Note
 
-In many cases, it can be useful to return a specific, user-defined type.
-For example:
-
-    struct Distance {
-        int value;
-        int unit = 1;   // 1 means meters
-    };
-
-    Distance d1 = measure(obj1);        // access d1.value and d1.unit
-    auto d2 = measure(obj2);            // access d2.value and d2.unit
-    auto [value, unit] = measure(obj3); // access value and unit; somewhat redundant
-                                        // to people who know measure()
-    auto [x, y] = measure(obj4);        // don't; it's likely to be confusing
-
-The overly-generic `pair` and `tuple` should be used only when the value returned represents independent entities rather than an abstraction.
-
-Another example, use a specific type along the lines of `variant<T, error_code>`, rather than using the generic `tuple`.
-
-##### Note
-
-When the tuple to be returned is initialized from local variables that are expensive to copy,
+When the object to be returned is initialized from local variables that are expensive to copy,
 explicit `move` may be helpful to avoid copying:
 
     pair<LargeObject, LargeObject> f(const string& input)
@@ -3354,10 +3337,31 @@ Alternatively,
 
 Note this is different from the `return move(...)` anti-pattern from [ES.56](#Res-move)
 
+##### Note
+
+For `struct`s where one member represents the success of an operation, adding an explicit conversion to `bool` is helpful:
+
+    struct parse_result {
+        bool success;
+        int value;
+        explicit operator bool() const { return success; }
+    };
+
+    parse_result parse_int(string_view s) { /* ... */ }
+
+    void f()
+    {
+        if (parse_result result = parse_int("123")) { use(result.value); }
+    }
+
+In most cases, C++17 `optional` and C++23 `expected` can replace this pattern.
+
 ##### Enforcement
 
 * Output parameters should be replaced by return values.
   An output parameter is one that the function writes to, invokes a non-`const` member function, or passes on as a non-`const`.
+* `pair` or `tuple` return types should be replaced by `struct`, if possible.
+  In variadic templates, `tuple` is often unavoidable.
 
 ### <a name="Rf-ptr-ref"></a>F.60: Prefer `T*` over `T&` when "no argument" is a valid option
 

--- a/CppCoreGuidelines.md
+++ b/CppCoreGuidelines.md
@@ -3333,6 +3333,7 @@ For example:
 The overly generic `pair` and `tuple` should be used only when the value returned represents independent entities rather than an abstraction.
 
 Another option is to use `optional<T>` or `expected<T, error_code>`, rather than `pair` or `tuple`.
+When used appropriately these types convey more information about what the members mean than `pair<T, bool>` or `pair<T, error_code>` do.
 
 ##### Note
 


### PR DESCRIPTION
This PR overhauls and modernizes the current advice. In short, we should not recommend returning `pair` or `tuple`.

## Rationale

### 1. Modern C++ has excellent support for `struct`

C++20 has added `operator<=> = default` eliminates practically all uses of `std::pair`. Furthermore, it has made direct-initialization of aggregate types possible, so that `struct`s can be used with `emplace`, taking away even more reasons to use `std::pair`.

`struct` also supports aggregate initialization with designated initializers, unlike `std::pair` and `std::tuple`, which aren't aggregates.

### 2. `std::pair` and `std::tuple` are bad for code quality

`std::pair` hurts code quality. Replacing meaningful member names with `first` and `second` is strictly worse. The few cases where there is no meaningful name are usually homogeneous cases (e.g. `std::minmax` could return `std::array<T, 2>`).

Consensus in the C++ community has overwhelmingly shifted against the use of `std::pair` or `std::tuple`:
- `std::minmax` returned `std::pair` but `std::ranges::minmax` return `std::ranges::min_max_result`.
- `std::from_chars` returns `std::from_chars_result`.
- ...

`std::tuple` is even worse because it forces the user to access members with `std::get<N>` which is even more confusing than `.first` and `.second`, and tremendously more confusing than `.meaningful_name`. `std::tuple` is only useful in variadic templates. This exception is left in the guideline.

### 3. `std::pair` and `std::tuple` have legacy baggage

 `std::pair` is an incredibly bloated type for what it does. It has 11 constructors while providing relatively little value in most of its uses. `std::tuple` has 28 constructors.

Furthermore, `std:tuple` is not ABI-trivial in libstdc++, which results in `std::tuple<int>` being passed via stack and not via register. Overall, a simple `struct` can be a major boost to compilation speed and even runtime performance.

### 4. Almost no return type *obviously* meets the requirement in the old guideline

The old wording states:
> The overly-generic `pair` and `tuple` should be used only when the value returned represents independent entities rather than an abstraction.

Almost no function *obviously* meets this hurdle. `std::minmax` doesn't because it returns a one-dimensional range, specified by a minimum and maximum, not two entirely independent entities. `std::from_chars` doesn't because it returns a pre-C++23 `std::expected`-like type. In general, pairs where one member indicates success are abstracted by an optional/expected value.

I find this guideline wishy washy because you can almost always argue that the two entities are not independent, or the other way.

The only example in the standard library I can think of where `std::pair` clearly makes sense is key/value pairs in `std::map, since the key and value can be accessed and used independently, other than being located in the same data structure. Even so, I'm sure you'll find someone who would argue they are not two independent entities.

### 5. `std::tie` is often bad practice

The current guideline contains the positive example:
> ```cpp
> Sometype iter;                                // default initialize if we haven't already
> Someothertype success;                        // used these variables for some other purpose
> 
> tie(iter, success) = my_set.insert("Hello");   // normal return value
> if (success) do_something_with(iter);
> ```

This is bad because
1. the advice conflicts with [C.49: Prefer initialization to assignment in constructors](http://isocpp.github.io/CppCoreGuidelines/CppCoreGuidelines#Rc-initialize) (this is not a constructor, but the same rationale applies)
2. this advice conflicts with [Con.1: By default, make objects immutable](http://isocpp.github.io/CppCoreGuidelines/CppCoreGuidelines#Rconst-immutable) (the result could easily be immutable, but late-initialization through `std::tie`-assignment prevents this)
3. this advice (at least in this style) conflicts with [ES.20: Always initialize an object](http://isocpp.github.io/CppCoreGuidelines/CppCoreGuidelines#Res-always) (assuming `Someothertype` is meant to be `bool`-like)
4. structured bindings have largely obsoleted this practice

`std::tie` still has a small handful of uses, but most have been replaced by
- structured bindings (C++17)
- defaulted comparisons (C++20)

`std::tie` is more of a historical relic and increasingly niche utility, rather than something we need to recommend in this guideline, especially if what we're recommend is bad practice that conflicts with other rules.