### PR TITLE
ES.87 (redundant `==` or `!=`) Fix dynamic_cast to Circle pointer

### DIFF
--- a/CppCoreGuidelines.md
+++ b/CppCoreGuidelines.md
@@ -13335,9 +13335,9 @@ whereas `if (p != nullptr)` would be a long-winded workaround.
 
 This rule is especially useful when a declaration is used as a condition
 
-    if (auto pc = dynamic_cast<Circle>(ps)) { ... } // execute if ps points to a kind of Circle, good
+    if (auto pc = dynamic_cast<Circle*>(ps)) { ... } // execute if ps points to a kind of Circle, good
 
-    if (auto pc = dynamic_cast<Circle>(ps); pc != nullptr) { ... } // not recommended
+    if (auto pc = dynamic_cast<Circle*>(ps); pc != nullptr) { ... } // not recommended
 
 ##### Example
 


### PR DESCRIPTION
The second ES.87 example seemed to mistakenly assume that `Circle` is pointer type, by the way it was using `dynamic_cast`. However, `Circle` is meant to be a class type instead. This fix is consistent with other examples, that also do `dynamic_cast<Circle*>`.