### PR TITLE
Removed confusing comments (#2076)

### DIFF
--- a/CppCoreGuidelines.md
+++ b/CppCoreGuidelines.md
@@ -4148,8 +4148,6 @@ It's confusing. Writing `[=]` in a member function appears to capture by value, 
             // ...
 
             auto lambda = [=] { use(i, x); };   // BAD: "looks like" copy/value capture
-            // [&] has identical semantics and copies the this pointer under the current rules
-            // [=,this] and [&,this] are not much better, and confusing
 
             x = 42;
             lambda(); // calls use(0, 42);


### PR DESCRIPTION
This rule is about "don’t use [=] default capture". It is stated in the synopsis but also in the enforcement. The description contains an example that contains two comments that are about something else, forbidding other constructs as well:

 // [&] has identical semantics and copies the this pointer under the current rules
 // [=,this] and [&,this] are not much better, and confusing

C++ core guideline rules should have all one clear purpose. So if this is really important extra info, I suggest to create a separate rule for this. The comments that are removed avoid questions that I get about this rule.