### PR TITLE
Rs-incform: clarify what a relative path is and offer implementation suggestion

### DIFF
--- a/CppCoreGuidelines.md
+++ b/CppCoreGuidelines.md
@@ -19629,9 +19629,18 @@ Failing to follow this results in difficult to diagnose errors due to picking up
 
 Library creators should put their headers in a folder and have clients include those files using the relative path `#include <some_library/common.h>`
 
+##### Project Example
+
+Consider a project with modules where src/module2/foo.cpp is using src/module1/utilities.hpp:
+
+    projectRoot/src/module1/utilities.hpp
+    projectRoot/src/module2/foo.cpp         // #include "../module1/utilities.hpp" OR #include "utilities.hpp" with -I../module1
+
+foo.cpp can `#include "../module1/utilities.hpp"` or it can `#include "utilities.hpp"` and provide the compiler with the relative path to module1 (e.g. `g++ -o foo.o -I../module1 foo.cpp`).  Using either quoted form, makes it clear that utilities.hpp is part of the project and will remain with the project when it is cloned. Likewise, headers included using angle brackets such as `#include <string>` cannot be modified in the project.  If an angle-bracket header is modified, it can impact many projects including those of other users on the system.
+
 ##### Enforcement
 
-A test should identify whether headers referenced via `""` could be referenced with `<>`.
+A test should identify whether headers referenced via `""` could be referenced with `<>`.  Compilers can report the absolute path of file being referenced in a `#include` directive and using this information, the test can verify that all includes of headers within the project root are included using quotes.
 
 ### <a name="Rs-portable-header-id"></a>SF.13: Use portable header identifiers in `#include` statements
 


### PR DESCRIPTION
The **Prefer the quoted form of `#include` for files relative to the including file and the angle bracket form everywhere else** is nice. This pull request is to clarify what relative path is, which then makes it very easy to enforce:

- Add and example clarifying that #include "utilities.hpp" or #include "../module1/utilities.hpp" can resolve to same file and are both relative.

- With this clarification, enforcement becomes very easy because compilers can report the absolute path of the file being reference.