### PR TITLE
C.45 Enforcement about _user-defined non-defaulted_ default constructors

### DIFF
--- a/CppCoreGuidelines.md
+++ b/CppCoreGuidelines.md
@@ -5799,7 +5799,7 @@ Using default member initializers lets the compiler generate the function for yo
 
 ##### Enforcement
 
-(Simple) A default constructor should do more than just initialize data members with constants.
+(Simple) A user-defined non-defaulted default constructor should do more than just initialize data members with constants.
 
 ### <a name="Rc-explicit"></a>C.46: By default, declare single-argument constructors explicit
 


### PR DESCRIPTION
Clarified that the Enforcement of [C.45: Don't define a default constructor that only initializes data members...](https://isocpp.github.io/CppCoreGuidelines/CppCoreGuidelines#c45-dont-define-a-default-constructor-that-only-initializes-data-members-use-default-member-initializers-instead) is specifically about _user-defined non-defaulted_ default constructors.