### PR TITLE
Fix invalid regex in scripts/python/md-split.py

### DIFF
--- a/scripts/python/md-split.py
+++ b/scripts/python/md-split.py
@@ -181,7 +181,7 @@ def is_inside_code(line, indent_depth):
 def stripped(line):
     # Remove well-formed html tags, fixing mistakes by legitimate users
     sline = TAG_REGEX.sub('', line)
-    sline = re.sub('[()\[\]#*]', ' ', line)
+    sline = re.sub(r'[()[\]#*]', ' ', line)
     return sline
 
 def dedent(line, indent_depth):


### PR DESCRIPTION
The `[` character doesn't need to be escaped.

The `]` character needs to be escaped as `\\]` or as `\]` in a raw string.

This fixes warnings seen in the CI checks:

```
##################### Tabs check ##################
/home/runner/work/CppCoreGuidelines/CppCoreGuidelines/scripts/./python/md-split.py:184: SyntaxWarning: invalid escape sequence '\['
  sline = re.sub('[()\[\]#*]', ' ', line)
```