### PR TITLE
Fix sidebar anchors for recent changes

### DIFF
--- a/_includes/sidebar.html
+++ b/_includes/sidebar.html
@@ -22,36 +22,36 @@
       <!-- Items have to be added manually until for now -->
       <b><a class="sidebar-nav-item active" href="#main">Top</a></b>
 
-      <a class="sidebar-nav-item active" href="#S-introduction">In: Introduction</a>
-      <a class="sidebar-nav-item active" href="#S-philosophy">P: Philosophy</a>
-      <a class="sidebar-nav-item active" href="#S-interfaces">I: Interfaces</a>
-      <a class="sidebar-nav-item active" href="#S-functions">F: Functions</a>
-      <a class="sidebar-nav-item active" href="#S-class">C: Classes and class hierarchies</a>
-      <a class="sidebar-nav-item active" href="#S-enum">Enum: Enumerations</a>
-      <a class="sidebar-nav-item active" href="#S-resource">R: Resource management</a>
-      <a class="sidebar-nav-item active" href="#S-expr">ES: Expressions and statements</a>
-      <a class="sidebar-nav-item active" href="#S-performance">Per: Performance</a>
-      <a class="sidebar-nav-item active" href="#S-concurrency">CP: Concurrency</a>
-      <a class="sidebar-nav-item active" href="#S-errors">E: Error handling</a>
-      <a class="sidebar-nav-item active" href="#S-const">Con: Constants and immutability</a>
-      <a class="sidebar-nav-item active" href="#S-templates">T: Templates and generic programming</a>
-      <a class="sidebar-nav-item active" href="#S-cpl">CPL: C-style programming</a>
-      <a class="sidebar-nav-item active" href="#S-source">SF: Source files</a>
-      <a class="sidebar-nav-item active" href="#S-stdlib">SL: The Standard library</a>
+      <a class="sidebar-nav-item active" href="#s-introduction">In: Introduction</a>
+      <a class="sidebar-nav-item active" href="#s-philosophy">P: Philosophy</a>
+      <a class="sidebar-nav-item active" href="#s-interfaces">I: Interfaces</a>
+      <a class="sidebar-nav-item active" href="#s-functions">F: Functions</a>
+      <a class="sidebar-nav-item active" href="#s-class">C: Classes and class hierarchies</a>
+      <a class="sidebar-nav-item active" href="#s-enum">Enum: Enumerations</a>
+      <a class="sidebar-nav-item active" href="#s-resource">R: Resource management</a>
+      <a class="sidebar-nav-item active" href="#s-expr">ES: Expressions and statements</a>
+      <a class="sidebar-nav-item active" href="#s-performance">Per: Performance</a>
+      <a class="sidebar-nav-item active" href="#s-concurrency">CP: Concurrency</a>
+      <a class="sidebar-nav-item active" href="#s-errors">E: Error handling</a>
+      <a class="sidebar-nav-item active" href="#s-const">Con: Constants and immutability</a>
+      <a class="sidebar-nav-item active" href="#s-templates">T: Templates and generic programming</a>
+      <a class="sidebar-nav-item active" href="#s-cpl">CPL: C-style programming</a>
+      <a class="sidebar-nav-item active" href="#s-source">SF: Source files</a>
+      <a class="sidebar-nav-item active" href="#s-stdlib">SL: The Standard library</a>
       <br/>
-      <a class="sidebar-nav-item active" href="#S-A">A: Architectural Ideas</a>
-      <a class="sidebar-nav-item active" href="#S-not">NR: Non-Rules and myths</a>
-      <a class="sidebar-nav-item active" href="#S-references">RF: References</a>
-      <a class="sidebar-nav-item active" href="#S-profile">Pro: Profiles</a>
-      <a class="sidebar-nav-item active" href="#S-gsl">GSL: Guideline support library</a>
-      <a class="sidebar-nav-item active" href="#S-naming">NL: Naming and layout</a>
-      <a class="sidebar-nav-item active" href="#S-faq">FAQ: Frequently asked questions</a>
-      <a class="sidebar-nav-item active" href="#S-libraries">Appendix A: Libraries</a>
-      <a class="sidebar-nav-item active" href="#S-modernizing">Appendix B: Modernizing code</a>
-      <a class="sidebar-nav-item active" href="#S-discussion">Appendix C: Discussion</a>
-      <a class="sidebar-nav-item active" href="#S-tools">Appendix D: Tools support</a>
-      <a class="sidebar-nav-item active" href="#S-glossary">Glossary</a>
-      <a class="sidebar-nav-item active" href="#S-unclassified">To-do: Unclassified proto-rules</a>
+      <a class="sidebar-nav-item active" href="#s-a">A: Architectural Ideas</a>
+      <a class="sidebar-nav-item active" href="#s-not">NR: Non-Rules and myths</a>
+      <a class="sidebar-nav-item active" href="#s-references">RF: References</a>
+      <a class="sidebar-nav-item active" href="#s-profile">Pro: Profiles</a>
+      <a class="sidebar-nav-item active" href="#s-gsl">GSL: Guideline support library</a>
+      <a class="sidebar-nav-item active" href="#s-naming">NL: Naming and layout</a>
+      <a class="sidebar-nav-item active" href="#s-faq">FAQ: Frequently asked questions</a>
+      <a class="sidebar-nav-item active" href="#s-libraries">Appendix A: Libraries</a>
+      <a class="sidebar-nav-item active" href="#s-modernizing">Appendix B: Modernizing code</a>
+      <a class="sidebar-nav-item active" href="#s-discussion">Appendix C: Discussion</a>
+      <a class="sidebar-nav-item active" href="#s-tools">Appendix D: Tools support</a>
+      <a class="sidebar-nav-item active" href="#s-glossary">Glossary</a>
+      <a class="sidebar-nav-item active" href="#s-unclassified">To-do: Unclassified proto-rules</a>
         {% else %}
 
       <a class="sidebar-nav-item active" href="CppCoreGuidelines.html">Read the C++ Core Guidelines</a>


### PR DESCRIPTION
In ee52a861103b7f18674a861643cad6bb89bb56eb I made all the internal anchors all-lowercase. This makes the links in the separate sidebar file use the new anchors.

Fixes #2305