### PR TITLE
ES.49: Simplify named casts example

### DIFF
--- a/CppCoreGuidelines.md
+++ b/CppCoreGuidelines.md
@@ -12174,7 +12174,7 @@ The named casts are:
     class B { /* ... */ };
     class D { /* ... */ };
 
-    template<typename D> D* upcast(B* pb)
+    D* downcast(B* pb)
     {
         D* pd0 = pb;                        // error: no implicit conversion from B* to D*
         D* pd1 = (D*)pb;                    // legal, but what is done?


### PR DESCRIPTION
The use of a template function, whose `typename D` shadows the `class D` defined above, obscures the apparent intention of ES.49's example, which is to show how named casts can help prevent bugs that arise when two types are mistakenly assumed to be related.

Furthermore, the use of 'upcast' for the function name appears to be a typo; the example casts intend to show downcasts.