### PR TITLE
Use function call in Example of C.48: Prefer default member initializer

### DIFF
--- a/CppCoreGuidelines.md
+++ b/CppCoreGuidelines.md
@@ -5987,7 +5987,7 @@ How would a maintainer know whether `j` was deliberately uninitialized (probably
     class X2 {
         int i {666};
         string s {"qqq"};
-        int j {0};
+        int j {numeric_limits<int>::min()};
     public:
         X2() = default;        // all members are initialized to their defaults
         X2(int ii) :i{ii} {}   // s and j initialized to their defaults
@@ -6001,7 +6001,7 @@ How would a maintainer know whether `j` was deliberately uninitialized (probably
         string s;
         int j;
     public:
-        X3(int ii = 666, const string& ss = "qqq", int jj = 0)
+        X3(int ii = 666, const string& ss = "qqq", int jj = numeric_limits<int>::min())
             :i{ii}, s{ss}, j{jj} { }   // all members are initialized to their defaults
         // ...
     };


### PR DESCRIPTION
[Guideline C.48](https://isocpp.github.io/CppCoreGuidelines/CppCoreGuidelines#c48-prefer-default-member-initializers-to-member-initializers-in-constructors-for-constant-initializers) appears specifically about _constant_ initializers, and its Example only had literal constants (`666`, `"qqq"`, `0`) as initializers.

However, the guideline also applies when initializing a member by a function-call, like `numeric_limits<int>::min()`. This commit adjusts the Example accordingly.