### PR TITLE
Prefer default member initializers also for non-constant initializers

### DIFF
--- a/CppCoreGuidelines.md
+++ b/CppCoreGuidelines.md
@@ -4936,7 +4936,7 @@ Constructor rules:
 * [C.45: Don't define a default constructor that only initializes data members; use member initializers instead](#rc-default)
 * [C.46: By default, declare single-argument constructors `explicit`](#rc-explicit)
 * [C.47: Define and initialize data members in the order of member declaration](#rc-order)
-* [C.48: Prefer default member initializers to member initializers in constructors for constant initializers](#rc-in-class-initializer)
+* [C.48: Prefer default member initializers to member initializers in constructors](#rc-in-class-initializer)
 * [C.49: Prefer initialization to assignment in constructors](#rc-initialize)
 * [C.50: Use a factory function if you need "virtual behavior" during initialization](#rc-factory)
 * [C.51: Use delegating constructors to represent common actions for all constructors of a class](#rc-delegating)
@@ -5962,7 +5962,7 @@ To minimize confusion and errors. That is the order in which the initialization 
 
 **See also**: [Discussion](#sd-order)
 
-### <a name="rc-in-class-initializer"></a>C.48: Prefer default member initializers to member initializers in constructors for constant initializers
+### <a name="rc-in-class-initializer"></a>C.48: Prefer default member initializers to member initializers in constructors
 
 ##### Reason
 


### PR DESCRIPTION
Removed the restriction "for constant initializers" from guideline C.48, [Prefer default member initializers to member initializers in constructors for constant initializers](https://isocpp.github.io/CppCoreGuidelines/CppCoreGuidelines#rc-in-class-initializer)

- The restriction appears unnecessary, as discussed by issue #2332, showing the following example, having a non-constant (`now()`) as default member initializer, which also appears preferable:

```cpp
    class MyContainer {
        time_point<system_clock> creationTime{ system_clock::now() };  // Preferable, right?
        vector<int> data{};
    public:
        MyContainer() = default;
        explicit MyContainer(size_t n) : data(n) {}
        MyContainer(initializer_list<int> values) : data{ values } {}
    };
```

---

- Follow-up to pull request #2330 commit b057f2991a74496c17ace26077af231b34150221 (which was merged by Sergey Zubkov, @cubbimew)